### PR TITLE
Redesign Transaction V5 serialization

### DIFF
--- a/zebra-chain/src/sapling.rs
+++ b/zebra-chain/src/sapling.rs
@@ -20,7 +20,7 @@ pub use address::Address;
 pub use commitment::{CommitmentRandomness, NoteCommitment, ValueCommitment};
 pub use keys::Diversifier;
 pub use note::{EncryptedNote, Note, Nullifier, WrappedNoteKey};
-pub use output::Output;
+pub use output::{Output, OutputInTransactionV4};
 pub use shielded_data::{
     AnchorVariant, FieldNotPresent, PerSpendAnchor, SharedAnchor, ShieldedData,
 };

--- a/zebra-chain/src/sapling/arbitrary.rs
+++ b/zebra-chain/src/sapling/arbitrary.rs
@@ -4,8 +4,8 @@ use proptest::{arbitrary::any, array, collection::vec, prelude::*};
 use crate::primitives::Groth16Proof;
 
 use super::{
-    keys, note, tree, FieldNotPresent, NoteCommitment, Output, PerSpendAnchor, SharedAnchor, Spend,
-    ValueCommitment,
+    keys, note, tree, FieldNotPresent, NoteCommitment, Output, OutputInTransactionV4,
+    PerSpendAnchor, SharedAnchor, Spend, ValueCommitment,
 };
 
 impl Arbitrary for Spend<PerSpendAnchor> {
@@ -85,6 +85,16 @@ impl Arbitrary for Output {
                 zkproof,
             })
             .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
+}
+
+impl Arbitrary for OutputInTransactionV4 {
+    type Parameters = ();
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        any::<Output>().prop_map(OutputInTransactionV4).boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;

--- a/zebra-chain/src/sapling/spend.rs
+++ b/zebra-chain/src/sapling/spend.rs
@@ -27,14 +27,23 @@ use super::{commitment, note, tree, AnchorVariant, FieldNotPresent, PerSpendAnch
 /// there is a single `shared_anchor` for the entire transaction. This
 /// structural difference is modeled using the `AnchorVariant` type trait.
 ///
+/// `V4` transactions serialize the fields of spends and outputs together.
+/// `V5` transactions split them into multiple arrays.
+///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#spendencoding
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Spend<AnchorV: AnchorVariant> {
     /// A value commitment to the value of the input note.
     pub cv: commitment::ValueCommitment,
-    /// A root of the Sapling note commitment tree at some block height in the past.
+    /// An anchor for this spend.
     ///
-    /// Some transaction versions do not have this field.
+    /// The anchor is the root of the Sapling note commitment tree in a previous
+    /// block. This root should be in the best chain for a transaction to be
+    /// mined, and it must be in the relevant chain for a transaction to be
+    /// valid.
+    ///
+    /// Some transaction versions have a shared anchor, rather than a per-spend
+    /// anchor.
     pub per_spend_anchor: AnchorV::PerSpend,
     /// The nullifier of the input note.
     pub nullifier: note::Nullifier,
@@ -44,6 +53,24 @@ pub struct Spend<AnchorV: AnchorVariant> {
     pub zkproof: Groth16Proof,
     /// A signature authorizing this spend.
     pub spend_auth_sig: redjubjub::Signature<SpendAuth>,
+}
+
+/// The serialization prefix fields of a `Spend` in Transaction V5.
+///
+/// In `V5` transactions, spends are split into multiple arrays, so the prefix,
+/// proof, and signature must be serialised and deserialized separately.
+///
+/// Serialized as `SpendDescriptionV5` in [protocol specification §7.3][ps].
+///
+/// [ps]: https://zips.z.cash/protocol/protocol.pdf#spendencoding
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SpendPrefixInTransactionV5 {
+    /// A value commitment to the value of the input note.
+    pub cv: commitment::ValueCommitment,
+    /// The nullifier of the input note.
+    pub nullifier: note::Nullifier,
+    /// The randomized public key for `spend_auth_sig`.
+    pub rk: redjubjub::VerificationKeyBytes<SpendAuth>,
 }
 
 impl From<(Spend<SharedAnchor>, tree::Root)> for Spend<PerSpendAnchor> {
@@ -98,6 +125,43 @@ impl Spend<PerSpendAnchor> {
     }
 }
 
+impl Spend<SharedAnchor> {
+    /// Combine the prefix and non-prefix fields from V5 transaction
+    /// deserialization.
+    pub fn from_v5_parts(
+        prefix: SpendPrefixInTransactionV5,
+        zkproof: Groth16Proof,
+        spend_auth_sig: redjubjub::Signature<SpendAuth>,
+    ) -> Spend<SharedAnchor> {
+        Spend::<SharedAnchor> {
+            cv: prefix.cv,
+            per_spend_anchor: FieldNotPresent,
+            nullifier: prefix.nullifier,
+            rk: prefix.rk,
+            zkproof,
+            spend_auth_sig,
+        }
+    }
+
+    /// Split out the prefix and non-prefix fields for V5 transaction
+    /// serialization.
+    pub fn into_v5_parts(
+        self,
+    ) -> (
+        SpendPrefixInTransactionV5,
+        Groth16Proof,
+        redjubjub::Signature<SpendAuth>,
+    ) {
+        let prefix = SpendPrefixInTransactionV5 {
+            cv: self.cv,
+            nullifier: self.nullifier,
+            rk: self.rk,
+        };
+
+        (prefix, self.zkproof, self.spend_auth_sig)
+    }
+}
+
 impl ZcashSerialize for Spend<PerSpendAnchor> {
     fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
         self.cv.zcash_serialize(&mut writer)?;
@@ -112,35 +176,10 @@ impl ZcashSerialize for Spend<PerSpendAnchor> {
 
 impl ZcashDeserialize for Spend<PerSpendAnchor> {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        use crate::sapling::{commitment::ValueCommitment, note::Nullifier};
         Ok(Spend {
-            cv: ValueCommitment::zcash_deserialize(&mut reader)?,
+            cv: commitment::ValueCommitment::zcash_deserialize(&mut reader)?,
             per_spend_anchor: tree::Root(reader.read_32_bytes()?),
-            nullifier: Nullifier::from(reader.read_32_bytes()?),
-            rk: reader.read_32_bytes()?.into(),
-            zkproof: Groth16Proof::zcash_deserialize(&mut reader)?,
-            spend_auth_sig: reader.read_64_bytes()?.into(),
-        })
-    }
-}
-
-impl ZcashSerialize for Spend<SharedAnchor> {
-    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
-        self.cv.zcash_serialize(&mut writer)?;
-        writer.write_32_bytes(&self.nullifier.into())?;
-        writer.write_all(&<[u8; 32]>::from(self.rk)[..])?;
-        // zkproof and spend_auth_sig are serialized separately
-        Ok(())
-    }
-}
-
-impl ZcashDeserialize for Spend<SharedAnchor> {
-    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
-        use crate::sapling::{commitment::ValueCommitment, note::Nullifier};
-        Ok(Spend {
-            cv: ValueCommitment::zcash_deserialize(&mut reader)?,
-            per_spend_anchor: FieldNotPresent,
-            nullifier: Nullifier::from(reader.read_32_bytes()?),
+            nullifier: note::Nullifier::from(reader.read_32_bytes()?),
             rk: reader.read_32_bytes()?.into(),
             zkproof: Groth16Proof::zcash_deserialize(&mut reader)?,
             spend_auth_sig: reader.read_64_bytes()?.into(),
@@ -149,8 +188,53 @@ impl ZcashDeserialize for Spend<SharedAnchor> {
 }
 
 // zkproof and spend_auth_sig are deserialized separately, so we can only
-// deserialize Spend<SharedAnchor> in the context of a transaction
+// deserialize Spend<SharedAnchor> in the context of a V5 transaction.
+//
+// Instead, implement serialization and deserialization for the
+// Spend<SharedAnchor> prefix fields, which are stored in the same array.
 
+impl ZcashSerialize for SpendPrefixInTransactionV5 {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        self.cv.zcash_serialize(&mut writer)?;
+        writer.write_32_bytes(&self.nullifier.into())?;
+        writer.write_all(&<[u8; 32]>::from(self.rk)[..])?;
+        Ok(())
+    }
+}
+
+impl ZcashDeserialize for SpendPrefixInTransactionV5 {
+    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        Ok(SpendPrefixInTransactionV5 {
+            cv: commitment::ValueCommitment::zcash_deserialize(&mut reader)?,
+            nullifier: note::Nullifier::from(reader.read_32_bytes()?),
+            rk: reader.read_32_bytes()?.into(),
+        })
+    }
+}
+
+/// In Transaction V5, SpendAuth signatures are serialized and deserialized in a
+/// separate array.
+impl ZcashSerialize for redjubjub::Signature<SpendAuth> {
+    fn zcash_serialize<W: io::Write>(&self, mut writer: W) -> Result<(), io::Error> {
+        writer.write_all(&<[u8; 64]>::from(*self)[..])?;
+        Ok(())
+    }
+}
+
+impl ZcashDeserialize for redjubjub::Signature<SpendAuth> {
+    fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
+        Ok(reader.read_64_bytes()?.into())
+    }
+}
+
+/// The size of a spend with a per-spend anchor.
+pub(crate) const ANCHOR_PER_SPEND_SIZE: u64 = SHARED_ANCHOR_SPEND_SIZE + 32;
+
+/// The size of a spend with a shared anchor, without associated fields.
+///
+/// This is the size of spends in the initial array, there are another
+/// 2 arrays of zkproofs and spend_auth_sigs required in the transaction format.
+pub(crate) const SHARED_ANCHOR_SPEND_PREFIX_SIZE: u64 = 32 + 32 + 32;
 /// The size of a spend with a shared anchor, including associated fields.
 ///
 /// A Spend contains: a 32 byte cv, a 32 byte anchor (transaction V4 only),
@@ -158,33 +242,32 @@ impl ZcashDeserialize for Spend<SharedAnchor> {
 /// in V5), and a 64 byte spendAuthSig (serialized separately in V5).
 ///
 /// [ps]: https://zips.z.cash/protocol/protocol.pdf#spendencoding
-pub(crate) const SHARED_ANCHOR_SPEND_FULL_SIZE: u64 = SHARED_ANCHOR_SPEND_INITIAL_SIZE + 192 + 64;
-/// The size of a spend with a shared anchor, without associated fields.
-///
-/// This is the size of spends in the initial array, there are another
-/// 2 arrays of zkproofs and spend_auth_sigs required in the transaction format.
-pub(crate) const SHARED_ANCHOR_SPEND_INITIAL_SIZE: u64 = 32 + 32 + 32;
+pub(crate) const SHARED_ANCHOR_SPEND_SIZE: u64 = SHARED_ANCHOR_SPEND_PREFIX_SIZE + 192 + 64;
 
-/// The size of a spend with a per-spend anchor.
-pub(crate) const ANCHOR_PER_SPEND_SIZE: u64 = SHARED_ANCHOR_SPEND_FULL_SIZE + 32;
+/// The maximum number of sapling spends in a valid Zcash on-chain transaction V4.
+impl TrustedPreallocate for Spend<PerSpendAnchor> {
+    fn max_allocation() -> u64 {
+        (MAX_BLOCK_BYTES - 1) / ANCHOR_PER_SPEND_SIZE
+    }
+}
 
-/// The maximum number of spends in a valid Zcash on-chain transaction V5.
+/// The maximum number of sapling spends in a valid Zcash on-chain transaction V5.
 ///
 /// If a transaction contains more spends than can fit in maximally large block, it might be
 /// valid on the network and in the mempool, but it can never be mined into a block. So
 /// rejecting these large edge-case transactions can never break consensus.
-impl TrustedPreallocate for Spend<SharedAnchor> {
+impl TrustedPreallocate for SpendPrefixInTransactionV5 {
     fn max_allocation() -> u64 {
         // Since a serialized Vec<Spend> uses at least one byte for its length,
         // and the associated fields are required,
         // a valid max allocation can never exceed this size
-        (MAX_BLOCK_BYTES - 1) / SHARED_ANCHOR_SPEND_FULL_SIZE
+        (MAX_BLOCK_BYTES - 1) / SHARED_ANCHOR_SPEND_SIZE
     }
 }
 
-/// The maximum number of spends in a valid Zcash on-chain transaction V4.
-impl TrustedPreallocate for Spend<PerSpendAnchor> {
+impl TrustedPreallocate for redjubjub::Signature<SpendAuth> {
     fn max_allocation() -> u64 {
-        (MAX_BLOCK_BYTES - 1) / ANCHOR_PER_SPEND_SIZE
+        // Each associated field must have a corresponding spend prefix.
+        SpendPrefixInTransactionV5::max_allocation()
     }
 }

--- a/zebra-chain/src/sapling/tests/preallocate.rs
+++ b/zebra-chain/src/sapling/tests/preallocate.rs
@@ -1,38 +1,46 @@
 //! Tests for trusted preallocation during deserialization.
 
-use super::super::{
-    output::{Output, OUTPUT_SIZE},
-    spend::{
-        Spend, ANCHOR_PER_SPEND_SIZE, SHARED_ANCHOR_SPEND_FULL_SIZE,
-        SHARED_ANCHOR_SPEND_INITIAL_SIZE,
-    },
-};
-
 use crate::{
     block::MAX_BLOCK_BYTES,
-    sapling::{AnchorVariant, PerSpendAnchor, SharedAnchor},
+    primitives::Groth16Proof,
+    sapling::{
+        output::{
+            Output, OutputInTransactionV4, OutputPrefixInTransactionV5, OUTPUT_PREFIX_SIZE,
+            OUTPUT_SIZE,
+        },
+        spend::{
+            Spend, SpendPrefixInTransactionV5, ANCHOR_PER_SPEND_SIZE,
+            SHARED_ANCHOR_SPEND_PREFIX_SIZE, SHARED_ANCHOR_SPEND_SIZE,
+        },
+        PerSpendAnchor, SharedAnchor,
+    },
     serialization::{TrustedPreallocate, ZcashSerialize},
 };
 
 use proptest::prelude::*;
-use std::convert::TryInto;
+use std::{cmp::max, convert::TryInto};
 
 proptest! {
-    /// Confirm that each spend takes exactly ANCHOR_PER_SPEND_SIZE bytes when serialized.
-    /// This verifies that our calculated `TrustedPreallocate::max_allocation()` is indeed an upper bound.
+    /// Confirm that each `Spend<PerSpendAnchor>` takes exactly
+    /// ANCHOR_PER_SPEND_SIZE bytes when serialized.
+    ///
+    /// This verifies that our calculated `TrustedPreallocate::max_allocation()`
+    /// is indeed an upper bound.
     #[test]
     fn anchor_per_spend_size_is_small_enough(spend in Spend::<PerSpendAnchor>::arbitrary_with(())) {
         let serialized = spend.zcash_serialize_to_vec().expect("Serialization to vec must succeed");
         prop_assert!(serialized.len() as u64 == ANCHOR_PER_SPEND_SIZE)
     }
 
-    /// Confirm that each spend takes exactly SHARED_SPEND_SIZE bytes when serialized.
+    /// Confirm that each `Spend<SharedAnchor>` takes exactly SHARED_SPEND_SIZE
+    /// bytes when serialized.
     #[test]
     fn shared_anchor_spend_size_is_small_enough(spend in Spend::<SharedAnchor>::arbitrary_with(())) {
-        let mut serialized_len = spend.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
-        serialized_len += spend.zkproof.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
-        serialized_len += &<[u8; 64]>::from(spend.spend_auth_sig).len();
-        prop_assert!(serialized_len as u64 == SHARED_ANCHOR_SPEND_FULL_SIZE)
+        let (prefix, zkproof, spend_auth_sig) = spend.into_v5_parts();
+        let mut serialized_len = prefix.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
+        serialized_len += zkproof.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
+        serialized_len += spend_auth_sig.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
+        prop_assert!(serialized_len as u64 == SHARED_ANCHOR_SPEND_SIZE)
     }
 }
 
@@ -49,7 +57,7 @@ proptest! {
             smallest_disallowed_serialized_len,
             largest_allowed_vec_len,
             largest_allowed_serialized_len,
-        ) = spend_max_allocation_is_big_enough(spend);
+        ) = max_allocation_is_big_enough(spend);
 
         // Check that our smallest_disallowed_vec is only one item larger than the limit
         prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == Spend::<PerSpendAnchor>::max_allocation());
@@ -64,44 +72,156 @@ proptest! {
         prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
     }
 
-    /// Verify trusted preallocation for `Spend<SharedAnchor>`
+    /// Verify trusted preallocation for `Spend<SharedAnchor>` and its split fields
     #[test]
     fn shared_spend_max_allocation_is_big_enough(spend in Spend::<SharedAnchor>::arbitrary_with(())) {
+        let (prefix, zkproof, spend_auth_sig) = spend.into_v5_parts();
         let (
             smallest_disallowed_vec_len,
             smallest_disallowed_serialized_len,
             largest_allowed_vec_len,
             largest_allowed_serialized_len,
-        ) = spend_max_allocation_is_big_enough(spend);
+        ) = max_allocation_is_big_enough(prefix);
 
-        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == Spend::<SharedAnchor>::max_allocation());
         // Calculate the actual size of all required Spend fields
-        //
-        // TODO: modify the test to serialize the associated zkproof and
-        // spend_auth_sig fields
-        prop_assert!((smallest_disallowed_serialized_len as u64)/SHARED_ANCHOR_SPEND_INITIAL_SIZE*SHARED_ANCHOR_SPEND_FULL_SIZE >= MAX_BLOCK_BYTES);
+        prop_assert!((smallest_disallowed_serialized_len as u64)/SHARED_ANCHOR_SPEND_PREFIX_SIZE*SHARED_ANCHOR_SPEND_SIZE >= MAX_BLOCK_BYTES);
+        prop_assert!((largest_allowed_serialized_len as u64)/SHARED_ANCHOR_SPEND_PREFIX_SIZE*SHARED_ANCHOR_SPEND_SIZE <= MAX_BLOCK_BYTES);
 
-        prop_assert!((largest_allowed_vec_len as u64) == Spend::<SharedAnchor>::max_allocation());
+        // Now check the serialization limits
+        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == SpendPrefixInTransactionV5::max_allocation());
+        prop_assert!((largest_allowed_vec_len as u64) == SpendPrefixInTransactionV5::max_allocation());
+        prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
+
+        // And check the other fields
+        let (
+            smallest_disallowed_vec_len,
+            _smallest_disallowed_serialized_len,
+            largest_allowed_vec_len,
+            largest_allowed_serialized_len,
+        ) = max_allocation_is_big_enough(zkproof);
+
+        // Proofs are special-cased, because a proof array is deserialized as
+        // part of both spends and outputs.
+        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == Groth16Proof::max_allocation());
+        prop_assert!((largest_allowed_vec_len as u64) == Groth16Proof::max_allocation());
+        prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
+
+        // Regardless of where they are deserialized, proofs must not exceed the
+        // greatest upper bound across spends and outputs.
+        prop_assert!((largest_allowed_vec_len as u64) <= max(SpendPrefixInTransactionV5::max_allocation(), OutputPrefixInTransactionV5::max_allocation()));
+
+
+        let (
+            smallest_disallowed_vec_len,
+            _smallest_disallowed_serialized_len,
+            largest_allowed_vec_len,
+            largest_allowed_serialized_len,
+        ) = max_allocation_is_big_enough(spend_auth_sig);
+
+        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == SpendPrefixInTransactionV5::max_allocation());
+        prop_assert!((largest_allowed_vec_len as u64) == SpendPrefixInTransactionV5::max_allocation());
         prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
     }
 }
 
-/// Return the following calculations on `spend`:
+proptest! {
+    /// Confirm that each output takes exactly OUTPUT_SIZE bytes when serialized
+    /// in a V4 or V5 transaction.
+    ///
+    /// This verifies that our calculated `TrustedPreallocate::max_allocation()`
+    /// is indeed an upper bound.
+    #[test]
+    fn output_size_is_small_enough(output in Output::arbitrary_with(())) {
+        let v4_serialized = output.clone().into_v4().zcash_serialize_to_vec().expect("Serialization to vec must succeed");
+        prop_assert!(v4_serialized.len() as u64 == OUTPUT_SIZE);
+
+        let (prefix, zkproof) = output.into_v5_parts();
+        let mut v5_serialized_len = prefix.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
+        v5_serialized_len += zkproof.zcash_serialize_to_vec().expect("Serialization to vec must succeed").len();
+        prop_assert!(v5_serialized_len as u64 == OUTPUT_SIZE)
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+
+    /// Verify that...
+    /// 1. The smallest disallowed vector of `Outputs`s is too large to fit in a Zcash block
+    /// 2. The largest allowed vector is small enough to fit in a legal Zcash block
+    ///
+    /// when serialized in a V4 or V5 transaction.
+    #[test]
+    fn output_max_allocation_is_big_enough(output in Output::arbitrary_with(())) {
+
+        let (
+            smallest_disallowed_vec_len,
+            smallest_disallowed_serialized_len,
+            largest_allowed_vec_len,
+            largest_allowed_serialized_len,
+        ) = max_allocation_is_big_enough(output.clone().into_v4());
+
+        // Check that our smallest_disallowed_vec is only one item larger than the limit
+        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == OutputInTransactionV4::max_allocation());
+        // Check that our smallest_disallowed_vec is too big to send as a protocol message
+        // Note that a serialized block always includes at least one byte for the number of transactions,
+        // so any serialized Vec<Spend> at least MAX_BLOCK_BYTES long is too large to fit in a block.
+        prop_assert!((smallest_disallowed_serialized_len as u64) >= MAX_BLOCK_BYTES);
+
+        // Check that our largest_allowed_vec contains the maximum number of spends
+        prop_assert!((largest_allowed_vec_len as u64) == OutputInTransactionV4::max_allocation());
+        // Check that our largest_allowed_vec is small enough to send as a protocol message
+        prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
+
+        let (prefix, zkproof) = output.into_v5_parts();
+        let (
+            smallest_disallowed_vec_len,
+            smallest_disallowed_serialized_len,
+            largest_allowed_vec_len,
+            largest_allowed_serialized_len,
+        ) = max_allocation_is_big_enough(prefix);
+
+        // Calculate the actual size of all required Output fields
+        prop_assert!((smallest_disallowed_serialized_len as u64)/OUTPUT_PREFIX_SIZE*OUTPUT_SIZE >= MAX_BLOCK_BYTES);
+        prop_assert!((largest_allowed_serialized_len as u64)/OUTPUT_PREFIX_SIZE*OUTPUT_SIZE <= MAX_BLOCK_BYTES);
+
+        // Now check the serialization limits
+        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == OutputPrefixInTransactionV5::max_allocation());
+        prop_assert!((largest_allowed_vec_len as u64) == OutputPrefixInTransactionV5::max_allocation());
+        prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
+
+        // And check the other fields
+        let (
+            smallest_disallowed_vec_len,
+            _smallest_disallowed_serialized_len,
+            largest_allowed_vec_len,
+            largest_allowed_serialized_len,
+        ) = max_allocation_is_big_enough(zkproof);
+
+        // Proofs are special-cased, because a proof array is deserialized as
+        // part of both spends and outputs.
+        prop_assert!(((smallest_disallowed_vec_len - 1) as u64) == Groth16Proof::max_allocation());
+        prop_assert!((largest_allowed_vec_len as u64) == Groth16Proof::max_allocation());
+        prop_assert!((largest_allowed_serialized_len as u64) <= MAX_BLOCK_BYTES);
+
+        // Regardless of where they are deserialized, proofs must not exceed the
+        // greatest upper bound across spends and outputs.
+        prop_assert!((largest_allowed_vec_len as u64) <= max(SpendPrefixInTransactionV5::max_allocation(), OutputPrefixInTransactionV5::max_allocation()));
+    }
+}
+
+/// Return the following calculations on `item`:
 ///   smallest_disallowed_vec_len
 ///   smallest_disallowed_serialized_len
 ///   largest_allowed_vec_len
 ///   largest_allowed_serialized_len
-fn spend_max_allocation_is_big_enough<AnchorV>(
-    spend: Spend<AnchorV>,
-) -> (usize, usize, usize, usize)
+fn max_allocation_is_big_enough<T>(item: T) -> (usize, usize, usize, usize)
 where
-    AnchorV: AnchorVariant,
-    Spend<AnchorV>: TrustedPreallocate + ZcashSerialize + Clone,
+    T: TrustedPreallocate + ZcashSerialize + Clone,
 {
-    let max_allocation: usize = Spend::max_allocation().try_into().unwrap();
+    let max_allocation: usize = T::max_allocation().try_into().unwrap();
     let mut smallest_disallowed_vec = Vec::with_capacity(max_allocation + 1);
-    for _ in 0..(Spend::max_allocation() + 1) {
-        smallest_disallowed_vec.push(spend.clone());
+    for _ in 0..(max_allocation + 1) {
+        smallest_disallowed_vec.push(item.clone());
     }
     let smallest_disallowed_serialized = smallest_disallowed_vec
         .zcash_serialize_to_vec()
@@ -121,49 +241,4 @@ where
         largest_allowed_vec.len(),
         largest_allowed_serialized.len(),
     )
-}
-
-proptest! {
-    /// Confirm that each output takes exactly OUTPUT_SIZE bytes when serialized.
-    /// This verifies that our calculated `TrustedPreallocate::max_allocation()` is indeed an upper bound.
-    #[test]
-    fn output_size_is_small_enough(output in Output::arbitrary_with(())) {
-        let serialized = output.zcash_serialize_to_vec().expect("Serialization to vec must succeed");
-        prop_assert!(serialized.len() as u64 == OUTPUT_SIZE)
-    }
-
-}
-
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(128))]
-
-    /// Verify that...
-    /// 1. The smallest disallowed vector of `Outputs`s is too large to fit in a Zcash block
-    /// 2. The largest allowed vector is small enough to fit in a legal Zcash block
-    #[test]
-    fn output_max_allocation_is_big_enough(output in Output::arbitrary_with(())) {
-
-        let max_allocation: usize = Output::max_allocation().try_into().unwrap();
-        let mut smallest_disallowed_vec = Vec::with_capacity(max_allocation + 1);
-        for _ in 0..(Output::max_allocation()+1) {
-            smallest_disallowed_vec.push(output.clone());
-        }
-        let smallest_disallowed_serialized = smallest_disallowed_vec.zcash_serialize_to_vec().expect("Serialization to vec must succeed");
-        // Check that our smallest_disallowed_vec is only one item larger than the limit
-        prop_assert!(((smallest_disallowed_vec.len() - 1) as u64) == Output::max_allocation());
-        // Check that our smallest_disallowed_vec is too big to be included in a valid block
-        // Note that a serialized block always includes at least one byte for the number of transactions,
-        // so any serialized Vec<Output> at least MAX_BLOCK_BYTES long is too large to fit in a block.
-        prop_assert!((smallest_disallowed_serialized.len() as u64) >= MAX_BLOCK_BYTES);
-
-        // Create largest_allowed_vec by removing one element from smallest_disallowed_vec without copying (for efficiency)
-        smallest_disallowed_vec.pop();
-        let largest_allowed_vec = smallest_disallowed_vec;
-        let largest_allowed_serialized = largest_allowed_vec.zcash_serialize_to_vec().expect("Serialization to vec must succeed");
-
-        // Check that our largest_allowed_vec contains the maximum number of Outputs
-        prop_assert!((largest_allowed_vec.len() as u64) == Output::max_allocation());
-        // Check that our largest_allowed_vec is small enough to fit in a Zcash block.
-        prop_assert!((largest_allowed_serialized.len() as u64) < MAX_BLOCK_BYTES);
-    }
 }

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -74,6 +74,8 @@ proptest! {
 proptest! {
     /// Serialize and deserialize `PerSpendAnchor` shielded data by including it
     /// in a V4 transaction
+    //
+    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
     fn shielded_data_v4_roundtrip(
         shielded_v4 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
@@ -91,33 +93,6 @@ proptest! {
             expiry_height: block::Height(0),
             joinsplit_data: None,
             sapling_shielded_data: Some(shielded_v4),
-        };
-        let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
-        let tx_parsed = data.zcash_deserialize_into().expect("randomized tx should deserialize");
-        prop_assert_eq![tx, tx_parsed];
-    }
-
-    /// Serialize and deserialize `SharedAnchor` shielded data by including it
-    /// in a V5 transaction
-    // TODO: enable this test when V5 serialization is implemented (#1829)
-    // #[test]
-    #[allow(dead_code)]
-    fn shielded_data_v5_roundtrip(
-        shielded_v5 in any::<sapling::ShieldedData<SharedAnchor>>(),
-    ) {
-        zebra_test::init();
-
-        // shielded data doesn't serialize by itself, so we have to stick it in
-        // a transaction
-
-        // stick `SharedAnchor` shielded data into a v5 transaction
-        let tx = Transaction::V5 {
-            lock_time: LockTime::min_lock_time(),
-            expiry_height: block::Height(0),
-            inputs: Vec::new(),
-            outputs: Vec::new(),
-            sapling_shielded_data: Some(shielded_v5),
-            rest: Vec::new(),
         };
         let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
         let tx_parsed = data.zcash_deserialize_into().expect("randomized tx should deserialize");

--- a/zebra-chain/src/sapling/tests/prop.rs
+++ b/zebra-chain/src/sapling/tests/prop.rs
@@ -8,22 +8,82 @@ use crate::{
 };
 
 use futures::future::Either;
+use sapling::OutputInTransactionV4;
 
 proptest! {
-
-    // Serialize and deserialize `PerSpendAnchor` and `SharedAnchor` shielded data
-    //  by including them in V4 and V5 transactions respectivly.
+    /// Serialize and deserialize `Spend<PerSpendAnchor>`
     #[test]
-    fn shielded_data_roundtrip(
+    fn spend_v4_roundtrip(
+        spend in any::<sapling::Spend<PerSpendAnchor>>(),
+    ) {
+        zebra_test::init();
+
+        let data = spend.zcash_serialize_to_vec().expect("spend should serialize");
+        let spend_parsed = data.zcash_deserialize_into().expect("randomized spend should deserialize");
+        prop_assert_eq![spend, spend_parsed];
+    }
+
+    /// Serialize and deserialize `Spend<SharedAnchor>`
+    #[test]
+    fn spend_v5_roundtrip(
+        spend in any::<sapling::Spend<SharedAnchor>>(),
+    ) {
+        zebra_test::init();
+
+        let (prefix, zkproof, spend_auth_sig) = spend.into_v5_parts();
+
+        let data = prefix.zcash_serialize_to_vec().expect("spend prefix should serialize");
+        let parsed = data.zcash_deserialize_into().expect("randomized spend prefix should deserialize");
+        prop_assert_eq![prefix, parsed];
+
+        let data = zkproof.zcash_serialize_to_vec().expect("spend zkproof should serialize");
+        let parsed = data.zcash_deserialize_into().expect("randomized spend zkproof should deserialize");
+        prop_assert_eq![zkproof, parsed];
+
+        let data = spend_auth_sig.zcash_serialize_to_vec().expect("spend auth sig should serialize");
+        let parsed = data.zcash_deserialize_into().expect("randomized spend auth sig should deserialize");
+        prop_assert_eq![spend_auth_sig, parsed];
+    }
+
+    /// Serialize and deserialize `Output`
+    #[test]
+    fn output_roundtrip(
+        output in any::<sapling::Output>(),
+    ) {
+        zebra_test::init();
+
+        // v4 format
+        let data = output.clone().into_v4().zcash_serialize_to_vec().expect("output should serialize");
+        let output_parsed = data.zcash_deserialize_into::<OutputInTransactionV4>().expect("randomized output should deserialize").into_output();
+        prop_assert_eq![&output, &output_parsed];
+
+        // v5 format
+        let (prefix, zkproof) = output.into_v5_parts();
+
+        let data = prefix.zcash_serialize_to_vec().expect("output prefix should serialize");
+        let parsed = data.zcash_deserialize_into().expect("randomized output prefix should deserialize");
+        prop_assert_eq![prefix, parsed];
+
+        let data = zkproof.zcash_serialize_to_vec().expect("output zkproof should serialize");
+        let parsed = data.zcash_deserialize_into().expect("randomized output zkproof should deserialize");
+        prop_assert_eq![zkproof, parsed];
+
+    }
+}
+
+proptest! {
+    /// Serialize and deserialize `PerSpendAnchor` shielded data by including it
+    /// in a V4 transaction
+    #[test]
+    fn shielded_data_v4_roundtrip(
         shielded_v4 in any::<sapling::ShieldedData<PerSpendAnchor>>(),
-        shielded_v5 in any::<sapling::ShieldedData<SharedAnchor>>()
     ) {
         zebra_test::init();
 
         // shielded data doesn't serialize by itself, so we have to stick it in
         // a transaction
 
-        // stick `PerSependAnchor` shielded data into a v4 transaction
+        // stick `PerSpendAnchor` shielded data into a v4 transaction
         let tx = Transaction::V4 {
             inputs: Vec::new(),
             outputs: Vec::new(),
@@ -35,6 +95,20 @@ proptest! {
         let data = tx.zcash_serialize_to_vec().expect("tx should serialize");
         let tx_parsed = data.zcash_deserialize_into().expect("randomized tx should deserialize");
         prop_assert_eq![tx, tx_parsed];
+    }
+
+    /// Serialize and deserialize `SharedAnchor` shielded data by including it
+    /// in a V5 transaction
+    // TODO: enable this test when V5 serialization is implemented (#1829)
+    // #[test]
+    #[allow(dead_code)]
+    fn shielded_data_v5_roundtrip(
+        shielded_v5 in any::<sapling::ShieldedData<SharedAnchor>>(),
+    ) {
+        zebra_test::init();
+
+        // shielded data doesn't serialize by itself, so we have to stick it in
+        // a transaction
 
         // stick `SharedAnchor` shielded data into a v5 transaction
         let tx = Transaction::V5 {
@@ -53,7 +127,7 @@ proptest! {
     /// Check that ShieldedData<PerSpendAnchor> is equal when `first` is swapped
     /// between a spend and an output
     //
-    // TODO: generalise this test for `ShieldedData<SharedAnchor>` (#1829)
+    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
     fn shielded_data_per_spend_swap_first_eq(shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>()) {
         use Either::*;
@@ -111,7 +185,7 @@ proptest! {
     /// Check that ShieldedData<PerSpendAnchor> serialization is equal if
     /// `shielded1 == shielded2`
     //
-    // TODO: generalise this test for `ShieldedData<SharedAnchor>` (#1829)
+    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
     fn shielded_data_per_spend_serialize_eq(shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(), shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()) {
         zebra_test::init();
@@ -158,7 +232,7 @@ proptest! {
     ///
     /// This test checks for extra fields that are not in `ShieldedData::eq`.
     //
-    // TODO: generalise this test for `ShieldedData<SharedAnchor>` (#1829)
+    // TODO: write a similar test for `ShieldedData<SharedAnchor>` (#1829)
     #[test]
     fn shielded_data_per_spend_field_assign_eq(shielded1 in any::<sapling::ShieldedData<PerSpendAnchor>>(), shielded2 in any::<sapling::ShieldedData<PerSpendAnchor>>()) {
         zebra_test::init();

--- a/zebra-chain/src/transaction/serialize.rs
+++ b/zebra-chain/src/transaction/serialize.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use super::*;
+use sapling::Output;
 
 impl ZcashDeserialize for jubjub::Fq {
     fn zcash_deserialize<R: io::Read>(mut reader: R) -> Result<Self, SerializationError> {
@@ -166,7 +167,11 @@ impl ZcashSerialize for Transaction {
                             spend.zcash_serialize(&mut writer)?;
                         }
                         writer.write_compactsize(shielded_data.outputs().count() as u64)?;
-                        for output in shielded_data.outputs() {
+                        for output in shielded_data
+                            .outputs()
+                            .cloned()
+                            .map(sapling::OutputInTransactionV4)
+                        {
                             output.zcash_serialize(&mut writer)?;
                         }
                     }
@@ -182,6 +187,8 @@ impl ZcashSerialize for Transaction {
                     None => {}
                 }
             }
+            // TODO: serialize sapling shielded data according to the V5 transaction spec
+            #[allow(unused_variables)]
             Transaction::V5 {
                 lock_time,
                 expiry_height,
@@ -198,27 +205,7 @@ impl ZcashSerialize for Transaction {
                 inputs.zcash_serialize(&mut writer)?;
                 outputs.zcash_serialize(&mut writer)?;
 
-                match sapling_shielded_data {
-                    None => {
-                        // Signal no value balance.
-                        writer.write_i64::<LittleEndian>(0)?;
-                        // Signal no shielded spends and no shielded outputs.
-                        writer.write_compactsize(0)?;
-                        writer.write_compactsize(0)?;
-                    }
-                    Some(shielded_data) => {
-                        shielded_data.value_balance.zcash_serialize(&mut writer)?;
-                        writer.write_compactsize(shielded_data.spends().count() as u64)?;
-                        for spend in shielded_data.spends() {
-                            spend.zcash_serialize(&mut writer)?;
-                        }
-                        writer.write_compactsize(shielded_data.outputs().count() as u64)?;
-                        for output in shielded_data.outputs() {
-                            output.zcash_serialize(&mut writer)?;
-                        }
-                        writer.write_all(&<[u8; 64]>::from(shielded_data.binding_sig)[..])?;
-                    }
-                }
+                // TODO: serialize sapling shielded data according to the V5 transaction spec
 
                 // write the rest
                 writer.write_all(rest)?;
@@ -295,7 +282,11 @@ impl ZcashDeserialize for Transaction {
 
                 let value_balance = (&mut reader).zcash_deserialize_into()?;
                 let mut shielded_spends = Vec::zcash_deserialize(&mut reader)?;
-                let mut shielded_outputs = Vec::zcash_deserialize(&mut reader)?;
+                let mut shielded_outputs =
+                    Vec::<sapling::OutputInTransactionV4>::zcash_deserialize(&mut reader)?
+                        .into_iter()
+                        .map(Output::from_v4)
+                        .collect();
 
                 let joinsplit_data = OptV4Jsd::zcash_deserialize(&mut reader)?;
 
@@ -344,39 +335,7 @@ impl ZcashDeserialize for Transaction {
                 let inputs = Vec::zcash_deserialize(&mut reader)?;
                 let outputs = Vec::zcash_deserialize(&mut reader)?;
 
-                let value_balance = (&mut reader).zcash_deserialize_into()?;
-                let shared_anchor = sapling::tree::Root(reader.read_32_bytes()?);
-                let mut shielded_spends = Vec::zcash_deserialize(&mut reader)?;
-                let mut shielded_outputs = Vec::zcash_deserialize(&mut reader)?;
-
-                // We can deserialize all sapling data in one go in V5 as the
-                //  internal structure line up with the serialized structure.
-
-                use futures::future::Either::*;
-                // Arbitraily use a spend for `first`, if both are present
-                let sapling_shielded_data = if !shielded_spends.is_empty() {
-                    Some(sapling::ShieldedData {
-                        value_balance,
-                        shared_anchor,
-                        first: Left(shielded_spends.remove(0)),
-                        rest_spends: shielded_spends,
-                        rest_outputs: shielded_outputs,
-                        binding_sig: reader.read_64_bytes()?.into(),
-                    })
-                } else if !shielded_outputs.is_empty() {
-                    Some(sapling::ShieldedData {
-                        value_balance,
-                        shared_anchor,
-                        first: Right(shielded_outputs.remove(0)),
-                        // the spends are actually empty here, but we use the
-                        // vec for consistency and readability
-                        rest_spends: shielded_spends,
-                        rest_outputs: shielded_outputs,
-                        binding_sig: reader.read_64_bytes()?.into(),
-                    })
-                } else {
-                    None
-                };
+                // TODO: deserialize sapling shielded data according to the V5 transaction spec
 
                 let mut rest = Vec::new();
                 reader.read_to_end(&mut rest)?;
@@ -386,7 +345,8 @@ impl ZcashDeserialize for Transaction {
                     expiry_height,
                     inputs,
                     outputs,
-                    sapling_shielded_data,
+                    // TODO: use deserialized sapling shielded data
+                    sapling_shielded_data: None,
                     rest,
                 })
             }


### PR DESCRIPTION
## Motivation

It's easy to accidentally serialize V5 transaction fields in the wrong order. So we should go back to the design stage for V5 transaction serialization.

## Solution

- Update the v5 transaction RFC with an explicit design for serialization
  - Only have serialize and deserialize impls on types that are serialized as continuous bytes in V4 and V5 transactions
  - To avoid accidental serialization of `Output`s in the V4 format in V5 transactions, add a wrapper type, and move the serialization impls to that type
  - List the types that have serialization impls, noting new impls
  - Explain how to serialize types that don't have serialization impls, by splitting those types up into their parts
- Implement the design for sapling spends and outputs, to make sure it works
- Security: Implement trusted vector preallocation for spends and outputs

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Property Tests

## Review

@oxarbitrage should review, because it blocks https://github.com/ZcashFoundation/zebra/pull/1996

@dconnolly might also want to have a look, because it's a redesign.

## Follow Up Work

Add the serialization impls to the implementation section of https://github.com/zcashfoundation/zebra/issues/1829 and https://github.com/ZcashFoundation/zebra/issues/1979 (done!)