### PR TITLE
Update sapling_balances_match for Transaction v5

### DIFF
--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -215,7 +215,7 @@ where
                     }
 
                     if let Some(shielded_data) = sapling_shielded_data {
-                        check::shielded_balances_match(&shielded_data)?;
+                        check::sapling_balances_match(&shielded_data)?;
 
                         for spend in shielded_data.spends_per_anchor() {
                             // Consensus rule: cv and rk MUST NOT be of small

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -83,17 +83,24 @@ pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> 
     }
 }
 
-/// Check that if there are no Spends or Outputs, that valueBalance is also 0.
+/// Check that if there are no Spends or Outputs, the Sapling valueBalance is also 0.
 ///
-/// https://zips.z.cash/protocol/protocol.pdf#consensusfrombitcoin
-pub fn shielded_balances_match<AnchorV>(
-    shielded_data: &ShieldedData<AnchorV>,
+/// If effectiveVersion = 4 and there are no Spend descriptions or Output descriptions,
+/// then valueBalanceSapling MUST be 0.
+///
+/// This check is redundant for `Transaction::V5`, because the transaction format
+/// omits `valueBalanceSapling` when there are no spends and no outputs. But it's
+/// simpler to just do the redundant check anyway.
+///
+/// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
+pub fn sapling_balances_match<AnchorV>(
+    sapling_shielded_data: &ShieldedData<AnchorV>,
 ) -> Result<(), TransactionError>
 where
     AnchorV: AnchorVariant + Clone,
 {
-    if (shielded_data.spends().count() + shielded_data.outputs().count() != 0)
-        || i64::from(shielded_data.value_balance) == 0
+    if (sapling_shielded_data.spends().count() + sapling_shielded_data.outputs().count() != 0)
+        || i64::from(sapling_shielded_data.value_balance) == 0
     {
         Ok(())
     } else {

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -47,7 +47,7 @@ fn v5_fake_transactions() -> Result<(), Report> {
                     ..
                 } => {
                     if let Some(s) = sapling_shielded_data {
-                        super::check::shielded_balances_match(&s)?;
+                        super::check::sapling_balances_match(&s)?;
 
                         for spend in s.spends_per_anchor() {
                             super::check::spend_cv_rk_not_small_order(&spend)?


### PR DESCRIPTION
## Motivation

The `sapling_balances_match` is correct for Transaction v5, but we still need to quote from the spec, and explain why it is correct.

## Solution

- Quote from the spec
- Explain why the function is redunant for v5
- Rename the function so it's clear that it is sapling-specific

The code in this pull request has:
  - [x] Documentation Comments
  - [x] Unit Tests and Property Tests (in ZcashFoundation/zebra#2047)

## Review

@oxarbitrage can review and merge into #2047 when he is ready.
