### PR TITLE
Simplify transaction checks, add missing coinbase PrevOut check

### DIFF
--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -113,10 +113,62 @@ pub enum Transaction {
 }
 
 impl Transaction {
-    /// Compute the hash of this transaction.
+    // hashes
+
+    /// Compute the hash (id) of this transaction.
     pub fn hash(&self) -> Hash {
         Hash::from(self)
     }
+
+    /// Calculate the sighash for the current transaction
+    ///
+    /// # Details
+    ///
+    /// The `input` argument indicates the transparent Input for which we are
+    /// producing a sighash. It is comprised of the index identifying the
+    /// transparent::Input within the transaction and the transparent::Output
+    /// representing the UTXO being spent by that input.
+    ///
+    /// # Panics
+    ///
+    /// - if passed in any NetworkUpgrade from before NetworkUpgrade::Overwinter
+    /// - if called on a v1 or v2 transaction
+    /// - if the input index points to a transparent::Input::CoinBase
+    /// - if the input index is out of bounds for self.inputs()
+    pub fn sighash(
+        &self,
+        network_upgrade: NetworkUpgrade,
+        hash_type: sighash::HashType,
+        input: Option<(u32, transparent::Output)>,
+    ) -> blake2b_simd::Hash {
+        sighash::SigHasher::new(self, hash_type, network_upgrade, input).sighash()
+    }
+
+    // header
+
+    /// Get this transaction's lock time.
+    pub fn lock_time(&self) -> LockTime {
+        match self {
+            Transaction::V1 { lock_time, .. } => *lock_time,
+            Transaction::V2 { lock_time, .. } => *lock_time,
+            Transaction::V3 { lock_time, .. } => *lock_time,
+            Transaction::V4 { lock_time, .. } => *lock_time,
+            Transaction::V5 { lock_time, .. } => *lock_time,
+        }
+    }
+
+    /// Get this transaction's expiry height, if any.
+    pub fn expiry_height(&self) -> Option<block::Height> {
+        match self {
+            Transaction::V1 { .. } => None,
+            Transaction::V2 { .. } => None,
+            Transaction::V3 { expiry_height, .. } => Some(*expiry_height),
+            Transaction::V4 { expiry_height, .. } => Some(*expiry_height),
+            Transaction::V5 { expiry_height, .. } => Some(*expiry_height),
+        }
+    }
+
+    // transparent
 
     /// Access the transparent inputs of this transaction, regardless of version.
     pub fn inputs(&self) -> &[transparent::Input] {
@@ -140,27 +192,32 @@ impl Transaction {
         }
     }
 
-    /// Get this transaction's lock time.
-    pub fn lock_time(&self) -> LockTime {
-        match self {
-            Transaction::V1 { lock_time, .. } => *lock_time,
-            Transaction::V2 { lock_time, .. } => *lock_time,
-            Transaction::V3 { lock_time, .. } => *lock_time,
-            Transaction::V4 { lock_time, .. } => *lock_time,
-            Transaction::V5 { lock_time, .. } => *lock_time,
-        }
+    /// Returns `true` if this transaction is a coinbase transaction.
+    pub fn is_coinbase(&self) -> bool {
+        self.inputs().len() == 1
+            && matches!(
+                self.inputs().get(0),
+                Some(transparent::Input::Coinbase { .. })
+            )
     }
 
-    /// Get this transaction's expiry height, if any.
-    pub fn expiry_height(&self) -> Option<block::Height> {
-        match self {
-            Transaction::V1 { .. } => None,
-            Transaction::V2 { .. } => None,
-            Transaction::V3 { expiry_height, .. } => Some(*expiry_height),
-            Transaction::V4 { expiry_height, .. } => Some(*expiry_height),
-            Transaction::V5 { expiry_height, .. } => Some(*expiry_height),
-        }
+    /// Returns `true` if transaction contains any coinbase inputs.
+    pub fn contains_coinbase_input(&self) -> bool {
+        self.inputs()
+            .iter()
+            .any(|input| matches!(input, transparent::Input::Coinbase { .. }))
     }
+
+    /// Returns `true` if transaction contains any `PrevOut` inputs.
+    ///
+    /// `PrevOut` inputs are also known as `transparent` inputs in the spec.
+    pub fn contains_prevout_input(&self) -> bool {
+        self.inputs()
+            .iter()
+            .any(|input| matches!(input, transparent::Input::PrevOut { .. }))
+    }
+
+    // sprout
 
     /// Access the sprout::Nullifiers in this transaction, regardless of version.
     pub fn sprout_nullifiers(&self) -> Box<dyn Iterator<Item = &sprout::Nullifier> + '_> {
@@ -201,6 +258,8 @@ impl Transaction {
         }
     }
 
+    // sapling
+
     /// Access the sapling::Nullifiers in this transaction, regardless of version.
     pub fn sapling_nullifiers(&self) -> Box<dyn Iterator<Item = &sapling::Nullifier> + '_> {
         // This function returns a boxed iterator because the different
@@ -231,52 +290,5 @@ impl Transaction {
         }
     }
 
-    /// Returns `true` if transaction contains any coinbase inputs.
-    pub fn contains_coinbase_input(&self) -> bool {
-        self.inputs()
-            .iter()
-            .any(|input| matches!(input, transparent::Input::Coinbase { .. }))
-    }
-
-    /// Returns `true` if transaction contains any `PrevOut` inputs.
-    ///
-    /// `PrevOut` inputs are also known as `transparent` inputs in the spec.
-    pub fn contains_prevout_input(&self) -> bool {
-        self.inputs()
-            .iter()
-            .any(|input| matches!(input, transparent::Input::PrevOut { .. }))
-    }
-
-    /// Returns `true` if this transaction is a coinbase transaction.
-    pub fn is_coinbase(&self) -> bool {
-        self.inputs().len() == 1
-            && matches!(
-                self.inputs().get(0),
-                Some(transparent::Input::Coinbase { .. })
-            )
-    }
-
-    /// Calculate the sighash for the current transaction
-    ///
-    /// # Details
-    ///
-    /// The `input` argument indicates the transparent Input for which we are
-    /// producing a sighash. It is comprised of the index identifying the
-    /// transparent::Input within the transaction and the transparent::Output
-    /// representing the UTXO being spent by that input.
-    ///
-    /// # Panics
-    ///
-    /// - if passed in any NetworkUpgrade from before NetworkUpgrade::Overwinter
-    /// - if called on a v1 or v2 transaction
-    /// - if the input index points to a transparent::Input::CoinBase
-    /// - if the input index is out of bounds for self.inputs()
-    pub fn sighash(
-        &self,
-        network_upgrade: NetworkUpgrade,
-        hash_type: sighash::HashType,
-        input: Option<(u32, transparent::Output)>,
-    ) -> blake2b_simd::Hash {
-        sighash::SigHasher::new(self, hash_type, network_upgrade, input).sighash()
-    }
+    // TODO: orchard
 }

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -238,6 +238,15 @@ impl Transaction {
             .any(|input| matches!(input, transparent::Input::Coinbase { .. }))
     }
 
+    /// Returns `true` if transaction contains any `PrevOut` inputs.
+    ///
+    /// `PrevOut` inputs are also known as `transparent` inputs in the spec.
+    pub fn contains_prevout_input(&self) -> bool {
+        self.inputs()
+            .iter()
+            .any(|input| matches!(input, transparent::Input::PrevOut { .. }))
+    }
+
     /// Returns `true` if this transaction is a coinbase transaction.
     pub fn is_coinbase(&self) -> bool {
         self.inputs().len() == 1

--- a/zebra-consensus/src/block/check.rs
+++ b/zebra-consensus/src/block/check.rs
@@ -31,7 +31,7 @@ pub fn coinbase_is_first(block: &Block) -> Result<(), BlockError> {
         return Err(TransactionError::CoinbasePosition)?;
     }
     if rest.any(|tx| tx.contains_coinbase_input()) {
-        return Err(TransactionError::CoinbaseInputFound)?;
+        return Err(TransactionError::CoinbaseAfterFirst)?;
     }
 
     Ok(())

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -356,7 +356,7 @@ fn coinbase_validation_failure() -> Result<(), Report> {
 
     // Validate the block using coinbase_is_first
     let result = check::coinbase_is_first(&block).unwrap_err();
-    let expected = BlockError::Transaction(TransactionError::CoinbaseInputFound);
+    let expected = BlockError::Transaction(TransactionError::CoinbaseAfterFirst);
     assert_eq!(expected, result);
 
     // Validate the block using subsidy_is_valid, which does not detect this error

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -24,7 +24,10 @@ pub enum TransactionError {
     CoinbasePosition,
 
     #[error("coinbase input found in non-coinbase transaction")]
-    CoinbaseInputFound,
+    CoinbaseAfterFirst,
+
+    #[error("coinbase transaction MUST NOT have any transparent (PrevOut) inputs")]
+    CoinbaseHasPrevOutInput,
 
     #[error("coinbase transaction MUST NOT have any JoinSplit descriptions")]
     CoinbaseHasJoinSplit,

--- a/zebra-consensus/src/transaction.rs
+++ b/zebra-consensus/src/transaction.rs
@@ -162,7 +162,7 @@ where
 
                     // Handle transparent inputs and outputs.
                     if tx.is_coinbase() {
-                        check::coinbase_tx_no_joinsplit_or_spend(&tx)?;
+                        check::coinbase_tx_no_prevout_joinsplit_spend(&tx)?;
                     } else {
                         // feed all of the inputs to the script and shielded verifiers
                         // the script_verifier also checks transparent sighashes, using its own implementation

--- a/zebra-consensus/src/transaction/check.rs
+++ b/zebra-consensus/src/transaction/check.rs
@@ -19,78 +19,27 @@ use crate::error::TransactionError;
 /// * at least one of `tx_in_count`, `nSpendsSapling`, and `nActionsOrchard` MUST be non-zero.
 /// * at least one of `tx_out_count`, `nOutputsSapling`, and `nActionsOrchard` MUST be non-zero.
 ///
+/// This check counts both `Coinbase` and `PrevOut` transparent inputs.
+///
 /// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn has_inputs_and_outputs(tx: &Transaction) -> Result<(), TransactionError> {
-    // The consensus rule is written in terms of numbers, but our transactions
-    // hold enum'd data. Mixing pattern matching and numerical checks is risky,
-    // so convert everything to counts and sum up.
-    match tx {
-        // In Zebra, `inputs` contains both `PrevOut` (transparent) and `Coinbase` inputs.
-        Transaction::V4 {
-            inputs,
-            outputs,
-            joinsplit_data,
-            sapling_shielded_data,
-            ..
-        } => {
-            let tx_in_count = inputs.len();
-            let tx_out_count = outputs.len();
-            let n_joinsplit = joinsplit_data
-                .as_ref()
-                .map(|d| d.joinsplits().count())
-                .unwrap_or(0);
-            let n_spends_sapling = sapling_shielded_data
-                .as_ref()
-                .map(|d| d.spends().count())
-                .unwrap_or(0);
-            let n_outputs_sapling = sapling_shielded_data
-                .as_ref()
-                .map(|d| d.outputs().count())
-                .unwrap_or(0);
+    let tx_in_count = tx.inputs().len();
+    let tx_out_count = tx.outputs().len();
+    let n_joinsplit = tx.joinsplit_count();
+    let n_spends_sapling = tx.sapling_spends_per_anchor().count();
+    let n_outputs_sapling = tx.sapling_outputs().count();
 
-            if tx_in_count + n_spends_sapling + n_joinsplit == 0 {
-                Err(TransactionError::NoInputs)
-            } else if tx_out_count + n_outputs_sapling + n_joinsplit == 0 {
-                Err(TransactionError::NoOutputs)
-            } else {
-                Ok(())
-            }
-        }
+    // TODO: Orchard validation (#1980)
+    // For `Transaction::V5`:
+    // * at least one of `tx_in_count`, `nSpendsSapling`, and `nActionsOrchard` MUST be non-zero.
+    // * at least one of `tx_out_count`, `nOutputsSapling`, and `nActionsOrchard` MUST be non-zero.
 
-        Transaction::V5 {
-            inputs,
-            outputs,
-            sapling_shielded_data,
-            // TODO: Orchard validation (#1980)
-            ..
-        } => {
-            let tx_in_count = inputs.len();
-            let tx_out_count = outputs.len();
-            let n_spends_sapling = sapling_shielded_data
-                .as_ref()
-                .map(|d| d.spends().count())
-                .unwrap_or(0);
-            let n_outputs_sapling = sapling_shielded_data
-                .as_ref()
-                .map(|d| d.outputs().count())
-                .unwrap_or(0);
-
-            // TODO: Orchard validation (#1980)
-            // For `Transaction::V5`:
-            // * at least one of `tx_in_count`, `nSpendsSapling`, and `nActionsOrchard` MUST be non-zero.
-            // * at least one of `tx_out_count`, `nOutputsSapling`, and `nActionsOrchard` MUST be non-zero.
-            if tx_in_count + n_spends_sapling == 0 {
-                Err(TransactionError::NoInputs)
-            } else if tx_out_count + n_outputs_sapling == 0 {
-                Err(TransactionError::NoOutputs)
-            } else {
-                Ok(())
-            }
-        }
-
-        Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
-            unreachable!("tx version is checked first")
-        }
+    if tx_in_count + n_spends_sapling + n_joinsplit == 0 {
+        Err(TransactionError::NoInputs)
+    } else if tx_out_count + n_outputs_sapling + n_joinsplit == 0 {
+        Err(TransactionError::NoOutputs)
+    } else {
+        Ok(())
     }
 }
 
@@ -119,46 +68,24 @@ where
 ///
 /// In a version 5 coinbase transaction, the enableSpendsOrchard flag MUST be 0.
 ///
+/// This check only counts `PrevOut` transparent inputs.
+///
 /// https://zips.z.cash/protocol/protocol.pdf#txnencodingandconsensus
 pub fn coinbase_tx_no_prevout_joinsplit_spend(tx: &Transaction) -> Result<(), TransactionError> {
     if tx.is_coinbase() {
-        match tx {
-            // In Zebra, `inputs` contains both `PrevOut` (transparent) and `Coinbase` inputs.
-            tx if tx.contains_prevout_input() => Err(TransactionError::CoinbaseHasPrevOutInput),
-
-            // Check if there is any JoinSplitData.
-            Transaction::V4 {
-                joinsplit_data: Some(_),
-                ..
-            } => Err(TransactionError::CoinbaseHasJoinSplit),
-
-            // The ShieldedData contains both Spends and Outputs, and Outputs
-            // are allowed post-Heartwood, so we have to count Spends.
-            Transaction::V4 {
-                sapling_shielded_data: Some(sapling_shielded_data),
-                ..
-            } if sapling_shielded_data.spends().count() > 0 => {
-                Err(TransactionError::CoinbaseHasSpend)
-            }
-
-            Transaction::V5 {
-                sapling_shielded_data: Some(sapling_shielded_data),
-                ..
-            } if sapling_shielded_data.spends().count() > 0 => {
-                Err(TransactionError::CoinbaseHasSpend)
-            }
-
-            // TODO: Orchard validation (#1980)
-            // In a version 5 coinbase transaction, the enableSpendsOrchard flag MUST be 0.
-            Transaction::V4 { .. } | Transaction::V5 { .. } => Ok(()),
-
-            Transaction::V1 { .. } | Transaction::V2 { .. } | Transaction::V3 { .. } => {
-                unreachable!("tx version is checked first")
-            }
+        if tx.contains_prevout_input() {
+            return Err(TransactionError::CoinbaseHasPrevOutInput);
+        } else if tx.joinsplit_count() > 0 {
+            return Err(TransactionError::CoinbaseHasJoinSplit);
+        } else if tx.sapling_spends_per_anchor().count() > 0 {
+            return Err(TransactionError::CoinbaseHasSpend);
         }
-    } else {
-        Ok(())
+
+        // TODO: Orchard validation (#1980)
+        // In a version 5 coinbase transaction, the enableSpendsOrchard flag MUST be 0.
     }
+
+    Ok(())
 }
 
 /// Check that a Spend description's cv and rk are not of small order,

--- a/zebra-consensus/src/transaction/tests.rs
+++ b/zebra-consensus/src/transaction/tests.rs
@@ -38,7 +38,7 @@ fn v5_fake_transactions() -> Result<(), Report> {
             };
 
             // make sure there are no joinsplits nor spends in coinbase
-            super::check::coinbase_tx_no_joinsplit_or_spend(&transaction)?;
+            super::check::coinbase_tx_no_prevout_joinsplit_spend(&transaction)?;
 
             // validate the sapling shielded data
             match transaction {


### PR DESCRIPTION
## Motivation

In ZcashFoundation/zebra#2070, we add Transaction V5 to the existing transaction checks.

But we still need to:
- quote the consensus rules, and
- add Orchard TODOs.

We can also:
-  implement the missing "no PrevOuts" coinbase check, added a few days ago in zcash/zips@10710d9, and
- refactor the code to make it simpler.

## Review

@oxarbitrage can review and merge into #2070 when he is ready.

## Related Issues

Implements part of #1981.

## Follow Up Work

Do the rest of #1981.