### PR TITLE
add value_balance() for Block

### DIFF
--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -14,7 +14,7 @@ mod arbitrary;
 #[cfg(any(test, feature = "bench"))]
 pub mod tests;
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 pub use commitment::{ChainHistoryMmrRootHash, Commitment, CommitmentError};
 pub use hash::Hash;
@@ -28,6 +28,7 @@ pub use arbitrary::LedgerState;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    amount::NegativeAllowed,
     fmt::DisplayToDebug,
     orchard,
     parameters::{Network, NetworkUpgrade},
@@ -36,6 +37,7 @@ use crate::{
     sprout,
     transaction::Transaction,
     transparent,
+    value_balance::{ValueBalance, ValueBalanceError},
 };
 
 /// A Zcash block, containing a header and a list of transactions.
@@ -142,6 +144,18 @@ impl Block {
             .iter()
             .map(|transaction| transaction.orchard_nullifiers())
             .flatten()
+    }
+
+    /// Get all the value balances from this block by summing all the value balances
+    /// in each transaction the block has.
+    pub fn value_balance(
+        &self,
+        utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
+    ) -> Result<ValueBalance<NegativeAllowed>, ValueBalanceError> {
+        self.transactions
+            .iter()
+            .flat_map(|t| t.value_balance(utxos))
+            .sum()
     }
 }
 

--- a/zebra-chain/src/block.rs
+++ b/zebra-chain/src/block.rs
@@ -148,6 +148,10 @@ impl Block {
 
     /// Get all the value balances from this block by summing all the value balances
     /// in each transaction the block has.
+    ///
+    /// `utxos` must contain the utxos of every input in the transaction,
+    /// including UTXOs created by a transaction in this block,
+    /// then spent by a later transaction that's also in this block.
     pub fn value_balance(
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,

--- a/zebra-chain/src/transaction.rs
+++ b/zebra-chain/src/transaction.rs
@@ -676,7 +676,7 @@ impl Transaction {
     pub fn value_balance(
         &self,
         utxos: &HashMap<transparent::OutPoint, transparent::OrderedUtxo>,
-    ) -> Result<ValueBalance<NegativeAllowed>, AmountError> {
+    ) -> Result<ValueBalance<NegativeAllowed>, crate::value_balance::ValueBalanceError> {
         let mut value_balance = ValueBalance::zero();
 
         value_balance.set_transparent_value_balance(self.transparent_value_pool(utxos)?);

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -184,3 +184,28 @@ where
         self? - rhs
     }
 }
+
+impl<C> std::iter::Sum<ValueBalance<C>> for Result<ValueBalance<C>, ValueBalanceError>
+where
+    C: Constraint + Copy,
+{
+    fn sum<I: Iterator<Item = ValueBalance<C>>>(iter: I) -> Self {
+        iter.fold(Ok(ValueBalance::zero()), |acc, value_balance| {
+            Ok(ValueBalance {
+                transparent: (acc.clone()?.transparent + value_balance.transparent)?,
+                sprout: (acc.clone()?.sprout + value_balance.sprout)?,
+                sapling: (acc.clone()?.sapling + value_balance.sapling)?,
+                orchard: (acc.clone()?.orchard + value_balance.orchard)?,
+            })
+        })
+    }
+}
+
+impl<'amt, C> std::iter::Sum<&'amt ValueBalance<C>> for Result<ValueBalance<C>, ValueBalanceError>
+where
+    C: Constraint + std::marker::Copy + 'amt,
+{
+    fn sum<I: Iterator<Item = &'amt ValueBalance<C>>>(iter: I) -> Self {
+        iter.copied().sum()
+    }
+}

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -189,13 +189,13 @@ impl<C> std::iter::Sum<ValueBalance<C>> for Result<ValueBalance<C>, ValueBalance
 where
     C: Constraint + Copy,
 {
-    fn sum<I: Iterator<Item = ValueBalance<C>>>(iter: I) -> Self {
-        iter.fold(Ok(ValueBalance::zero()), |acc, value_balance| {
+    fn sum<I: Iterator<Item = ValueBalance<C>>>(mut iter: I) -> Self {
+        iter.try_fold(ValueBalance::zero(), |acc, value_balance| {
             Ok(ValueBalance {
-                transparent: (acc.clone()?.transparent + value_balance.transparent)?,
-                sprout: (acc.clone()?.sprout + value_balance.sprout)?,
-                sapling: (acc.clone()?.sapling + value_balance.sapling)?,
-                orchard: (acc?.orchard + value_balance.orchard)?,
+                transparent: (acc.transparent + value_balance.transparent)?,
+                sprout: (acc.sprout + value_balance.sprout)?,
+                sapling: (acc.sapling + value_balance.sapling)?,
+                orchard: (acc.orchard + value_balance.orchard)?,
             })
         })
     }

--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -195,7 +195,7 @@ where
                 transparent: (acc.clone()?.transparent + value_balance.transparent)?,
                 sprout: (acc.clone()?.sprout + value_balance.sprout)?,
                 sapling: (acc.clone()?.sapling + value_balance.sapling)?,
-                orchard: (acc.clone()?.orchard + value_balance.orchard)?,
+                orchard: (acc?.orchard + value_balance.orchard)?,
             })
         })
     }

--- a/zebra-chain/src/value_balance/tests/prop.rs
+++ b/zebra-chain/src/value_balance/tests/prop.rs
@@ -60,4 +60,32 @@ proptest! {
             ),
         }
     }
+
+    #[test]
+    fn test_sum(
+        value_balance1 in any::<ValueBalance<NegativeAllowed>>(),
+        value_balance2 in any::<ValueBalance<NegativeAllowed>>(),
+    ) {
+        zebra_test::init();
+
+        let collection = vec![value_balance1, value_balance2];
+
+        let transparent = value_balance1.transparent + value_balance2.transparent;
+        let sprout = value_balance1.sprout + value_balance2.sprout;
+        let sapling = value_balance1.sapling + value_balance2.sapling;
+        let orchard = value_balance1.orchard + value_balance2.orchard;
+
+        match (transparent, sprout, sapling, orchard) {
+            (Ok(transparent), Ok(sprout), Ok(sapling), Ok(orchard)) => prop_assert_eq!(
+                collection.iter().sum::<Result<ValueBalance<NegativeAllowed>, ValueBalanceError>>(),
+                Ok(ValueBalance {
+                    transparent,
+                    sprout,
+                    sapling,
+                    orchard,
+                })
+            ),
+            _ => prop_assert!(matches!(collection.iter().sum(), Err(ValueBalanceError::AmountError(_))))
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

Part of the value pools design. Implement the `value_pool()` method for `Block`. 

`Sum` is needed for `ValueBalance` in order to do this.

## Solution

Implement `Sum` for `ValueBalance` and `value_balance()` method for `Block`.

The code in this pull request has:
  - [ ] Documentation Comments
  - [ ] Unit Tests and Property Tests

## Review

## Related Issues

## Follow Up Work
