### PR TITLE
Add value balances to non finalized state

### DIFF
--- a/zebra-chain/src/value_balance.rs
+++ b/zebra-chain/src/value_balance.rs
@@ -1,7 +1,7 @@
 //! A type that can hold the four types of Zcash value pools.
 
 use crate::{
-    amount::{self, Amount, Constraint, NegativeAllowed, NonNegative},
+    amount::{self, Amount, Constraint, NegativeAllowed, NonNegative, MAX_MONEY},
     block::Block,
     transparent,
 };
@@ -317,6 +317,32 @@ where
             sapling,
             orchard,
         })
+    }
+
+    /// Create a fake value pool for testing purposes.
+    ///
+    /// The resulting [`ValueBalance`] will have half of the MAX_MONEY amount on each pool.
+    #[cfg(any(test, feature = "proptest-impl"))]
+    pub fn fake_populated_pool() -> ValueBalance<NonNegative> {
+        use std::convert::TryFrom;
+
+        let mut fake_value_pool = ValueBalance::zero();
+
+        let fake_transparent_value_balance =
+            ValueBalance::from_transparent_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+        let fake_sprout_value_balance =
+            ValueBalance::from_sprout_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+        let fake_sapling_value_balance =
+            ValueBalance::from_sapling_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+        let fake_orchard_value_balance =
+            ValueBalance::from_orchard_amount(Amount::try_from(MAX_MONEY / 2).unwrap());
+
+        fake_value_pool.set_transparent_value_balance(fake_transparent_value_balance);
+        fake_value_pool.set_sprout_value_balance(fake_sprout_value_balance);
+        fake_value_pool.set_sapling_value_balance(fake_sapling_value_balance);
+        fake_value_pool.set_orchard_value_balance(fake_orchard_value_balance);
+
+        fake_value_pool
     }
 }
 

--- a/zebra-consensus/src/block.rs
+++ b/zebra-consensus/src/block.rs
@@ -206,6 +206,8 @@ where
             let new_outputs = Arc::try_unwrap(known_utxos)
                 .expect("all verification tasks using known_utxos are complete");
 
+            let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
+
             // Finally, submit the block for contextual verification.
             let prepared_block = zs::PreparedBlock {
                 block,
@@ -213,6 +215,7 @@ where
                 height,
                 new_outputs,
                 transaction_hashes,
+                block_utxos,
             };
             match state_service
                 .ready_and()

--- a/zebra-state/src/arbitrary.rs
+++ b/zebra-state/src/arbitrary.rs
@@ -16,6 +16,7 @@ impl Prepare for Arc<Block> {
         let height = block.coinbase_height().unwrap();
         let transaction_hashes: Vec<_> = block.transactions.iter().map(|tx| tx.hash()).collect();
         let new_outputs = transparent::new_ordered_outputs(&block, transaction_hashes.as_slice());
+        let block_utxos = transparent::utxos_from_ordered_utxos(new_outputs.clone());
 
         PreparedBlock {
             block,
@@ -23,6 +24,7 @@ impl Prepare for Arc<Block> {
             height,
             new_outputs,
             transaction_hashes,
+            block_utxos,
         }
     }
 }

--- a/zebra-state/src/error.rs
+++ b/zebra-state/src/error.rs
@@ -180,6 +180,15 @@ pub enum ValidateContextError {
         transaction_hash: zebra_chain::transaction::Hash,
     },
 
+    #[error(
+        "error adding value balances to the chain value pool: \
+         {value_balance_error:?}"
+    )]
+    #[non_exhaustive]
+    AddValuePool {
+        value_balance_error: ValueBalanceError,
+    },
+
     #[error("error in Sapling note commitment tree")]
     SaplingNoteCommitmentTreeError(#[from] zebra_chain::sapling::tree::NoteCommitmentTreeError),
 

--- a/zebra-state/src/request.rs
+++ b/zebra-state/src/request.rs
@@ -81,6 +81,8 @@ pub struct PreparedBlock {
     // TODO: add these parameters when we can compute anchors.
     // sprout_anchor: sprout::tree::Root,
     // sapling_anchor: sapling::tree::Root,
+    /// Storage for all the utxos related to this block.
+    pub block_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
 }
 
 /// A contextually validated block, ready to be committed directly to the finalized state with
@@ -94,6 +96,7 @@ pub(crate) struct ContextuallyValidBlock {
     pub(crate) height: block::Height,
     pub(crate) new_outputs: HashMap<transparent::OutPoint, transparent::Utxo>,
     pub(crate) transaction_hashes: Vec<transaction::Hash>,
+    pub(crate) block_utxos: HashMap<transparent::OutPoint, transparent::Utxo>,
 }
 
 /// A finalized block, ready to be committed directly to the finalized state with
@@ -145,6 +148,7 @@ impl From<PreparedBlock> for ContextuallyValidBlock {
             height,
             new_outputs,
             transaction_hashes,
+            block_utxos,
         } = prepared;
         Self {
             block,
@@ -152,6 +156,7 @@ impl From<PreparedBlock> for ContextuallyValidBlock {
             height,
             new_outputs: transparent::utxos_from_ordered_utxos(new_outputs),
             transaction_hashes,
+            block_utxos,
         }
     }
 }
@@ -164,6 +169,7 @@ impl From<ContextuallyValidBlock> for FinalizedBlock {
             height,
             new_outputs,
             transaction_hashes,
+            block_utxos: _,
         } = contextually_valid;
         Self {
             block,

--- a/zebra-state/src/service/finalized_state.rs
+++ b/zebra-state/src/service/finalized_state.rs
@@ -599,6 +599,16 @@ impl FinalizedState {
             .zs_get(value_pool_cf, &())
             .unwrap_or_else(ValueBalance::zero)
     }
+
+    /// Allow to set up a fake value pool in the database for testing purposes.
+    //#[cfg(any(test, feature = "proptest-impl"))]
+    #[allow(dead_code)]
+    pub fn set_current_value_pool(&self, fake_value_pool: ValueBalance<NonNegative>) {
+        let mut batch = rocksdb::WriteBatch::default();
+        let value_pool_cf = self.db.cf_handle("tip_chain_value_pool").unwrap();
+        batch.zs_insert(value_pool_cf, (), fake_value_pool);
+        self.db.write(batch).unwrap();
+    }
 }
 
 // Drop isn't guaranteed to run, such as when we panic, or if someone stored

--- a/zebra-state/src/service/non_finalized_state.rs
+++ b/zebra-state/src/service/non_finalized_state.rs
@@ -167,6 +167,7 @@ impl NonFinalizedState {
             finalized_state.sapling_note_commitment_tree(),
             finalized_state.orchard_note_commitment_tree(),
             finalized_state.history_tree(),
+            finalized_state.current_value_pool(),
         );
         let (height, hash) = (prepared.height, prepared.hash);
 
@@ -182,16 +183,17 @@ impl NonFinalizedState {
     fn validate_and_commit(
         &self,
         parent_chain: Chain,
-        prepared: PreparedBlock,
+        mut prepared: PreparedBlock,
         finalized_state: &FinalizedState,
     ) -> Result<Chain, ValidateContextError> {
-        check::utxo::transparent_spend(
+        let utxos = check::utxo::transparent_spend(
             &prepared,
             &parent_chain.unspent_utxos(),
             &parent_chain.spent_utxos,
             finalized_state,
         )?;
 
+        prepared.block_utxos.extend(utxos);
         parent_chain.push(prepared)
     }
 

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -44,8 +44,9 @@ fn forked_equals_pushed() -> Result<()> {
             // use `fork_at_count` as the fork tip
             let fork_tip_hash = chain[fork_at_count - 1].hash;
 
-            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
-            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
+            let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), fake_value_pool);
+            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), fake_value_pool);
 
             for block in chain.iter().take(fork_at_count) {
                 partial_chain = partial_chain.push(block.clone())?;
@@ -115,7 +116,9 @@ fn finalized_equals_pushed() -> Result<()> {
         let chain = &chain[1..];
         // use `end_count` as the number of non-finalized blocks at the end of the chain
         let finalized_count = chain.len() - end_count;
-        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
+
+        let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, fake_value_pool);
 
         for block in chain.iter().take(finalized_count) {
             full_chain = full_chain.push(block.clone())?;

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -3,6 +3,7 @@ use std::{env, sync::Arc};
 use zebra_test::prelude::*;
 
 use zebra_chain::{
+    amount::NonNegative,
     block::{self, arbitrary::allow_all_transparent_coinbase_spends, Block},
     fmt::DisplayToDebug,
     history_tree::{HistoryTree, NonEmptyHistoryTree},
@@ -175,6 +176,9 @@ fn rejection_restores_internal_state() -> Result<()> {
                 ))| {
                   let mut state = NonFinalizedState::new(network);
                   let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+                  let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+                  finalized_state.set_current_value_pool(fake_value_pool);
 
                   // use `valid_count` as the number of valid blocks before an invalid block
                   let valid_tip_height = chain[valid_count - 1].height;

--- a/zebra-state/src/service/non_finalized_state/tests/prop.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/prop.rs
@@ -8,6 +8,7 @@ use zebra_chain::{
     history_tree::{HistoryTree, NonEmptyHistoryTree},
     parameters::NetworkUpgrade::*,
     parameters::{Network, *},
+    value_balance::ValueBalance,
     LedgerState,
 };
 
@@ -42,8 +43,8 @@ fn forked_equals_pushed() -> Result<()> {
             // use `fork_at_count` as the fork tip
             let fork_tip_hash = chain[fork_at_count - 1].hash;
 
-            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone());
-            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone());
+            let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
+            let mut partial_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree.clone(), ValueBalance::zero());
 
             for block in chain.iter().take(fork_at_count) {
                 partial_chain = partial_chain.push(block.clone())?;
@@ -113,7 +114,7 @@ fn finalized_equals_pushed() -> Result<()> {
         let chain = &chain[1..];
         // use `end_count` as the number of non-finalized blocks at the end of the chain
         let finalized_count = chain.len() - end_count;
-        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree);
+        let mut full_chain = Chain::new(network, Default::default(), Default::default(), finalized_tree, ValueBalance::zero());
 
         for block in chain.iter().take(finalized_count) {
             full_chain = full_chain.push(block.clone())?;
@@ -123,6 +124,7 @@ fn finalized_equals_pushed() -> Result<()> {
             full_chain.sapling_note_commitment_tree.clone(),
             full_chain.orchard_note_commitment_tree.clone(),
             full_chain.history_tree.clone(),
+            full_chain.value_balance,
         );
         for block in chain.iter().skip(finalized_count) {
             partial_chain = partial_chain.push(block.clone())?;
@@ -250,8 +252,8 @@ fn different_blocks_different_chains() -> Result<()> {
         } else {
             Default::default()
         };
-        let chain1 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree1);
-        let chain2 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree2);
+        let chain1 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree1, ValueBalance::zero());
+        let chain2 = Chain::new(Network::Mainnet, Default::default(), Default::default(), finalized_tree2, ValueBalance::zero());
 
         let block1 = vec1[1].clone().prepare();
         let block2 = vec2[1].clone().prepare();

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -4,6 +4,7 @@ use zebra_chain::{
     block::Block,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
+    value_balance::ValueBalance,
 };
 use zebra_test::prelude::*;
 
@@ -27,6 +28,7 @@ fn construct_empty() {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
 }
 
@@ -41,6 +43,7 @@ fn construct_single() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
     chain = chain.push(block.prepare())?;
 
@@ -68,6 +71,7 @@ fn construct_many() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
 
     for block in blocks {
@@ -92,6 +96,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
     lesser_chain = lesser_chain.push(less_block.prepare())?;
 
@@ -100,6 +105,7 @@ fn ord_matches_work() -> Result<()> {
         Default::default(),
         Default::default(),
         Default::default(),
+        ValueBalance::zero(),
     );
     bigger_chain = bigger_chain.push(more_block.prepare())?;
 

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -184,6 +184,9 @@ fn finalize_pops_from_best_chain_for_network(network: Network) -> Result<()> {
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
 
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
+
     state.commit_new_chain(block1.clone().prepare(), &finalized_state)?;
     state.commit_block(block2.clone().prepare(), &finalized_state)?;
     state.commit_block(child.prepare(), &finalized_state)?;
@@ -231,6 +234,9 @@ fn commit_block_extending_best_chain_doesnt_drop_worst_chains_for_network(
 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
 
     assert_eq!(0, state.chain_set.len());
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
@@ -323,6 +329,9 @@ fn longer_chain_with_more_work_wins_for_network(network: Network) -> Result<()> 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
 
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
+
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
     state.commit_block(long_chain_block1.prepare(), &finalized_state)?;
     state.commit_block(long_chain_block2.prepare(), &finalized_state)?;
@@ -364,6 +373,9 @@ fn equal_length_goes_to_more_work_for_network(network: Network) -> Result<()> {
 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
 
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
     state.commit_block(less_work_child.prepare(), &finalized_state)?;

--- a/zebra-state/src/service/non_finalized_state/tests/vectors.rs
+++ b/zebra-state/src/service/non_finalized_state/tests/vectors.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use zebra_chain::{
+    amount::NonNegative,
     block::Block,
     parameters::{Network, NetworkUpgrade},
     serialization::ZcashDeserializeInto,
@@ -274,6 +275,9 @@ fn shorter_chain_can_be_best_chain_for_network(network: Network) -> Result<()> {
 
     let mut state = NonFinalizedState::new(network);
     let finalized_state = FinalizedState::new(&Config::ephemeral(), network);
+
+    let fake_value_pool = ValueBalance::<NonNegative>::fake_populated_pool();
+    finalized_state.set_current_value_pool(fake_value_pool);
 
     state.commit_new_chain(block1.prepare(), &finalized_state)?;
     state.commit_block(long_chain_block1.prepare(), &finalized_state)?;


### PR DESCRIPTION
## Motivation

Add the value pools to the non finalized state part of the codebase and test the non negative consensus rules.

## Solution

The plan is to use the `value_pool()` we added in https://github.com/ZcashFoundation/zebra/pull/2599 to get the value balances of the finalized chain and then add the portion of the non finalized chain. Consensus rules are checked by constrain.

- Add a `value_balance` field to `Chain`. It will hold the value balance of the finalized + non finalized, it haves to be non negative.
- Add `block_utxos` field to `PreparedBlock`. It will hold all the utxos needed to calculate value balances. We need this to calculate the `Chain` value balance.
- Populate the `Chain` value balance in `update_chain_state_with` and `revert_chain_state_with`.