### PR TITLE
Validate funding stream addresses

### DIFF
--- a/zebra-consensus/src/block/subsidy/funding_streams.rs
+++ b/zebra-consensus/src/block/subsidy/funding_streams.rs
@@ -1,29 +1,27 @@
-//! Funding Streams calculations. - [§7.7][7.7]
+//! Funding Streams calculations. - [§7.8][7.8]
 //!
-//! [7.7]: https://zips.z.cash/protocol/protocol.pdf#subsidies
+//! [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 
 use zebra_chain::{
     amount::{Amount, Error, NonNegative},
     block::Height,
     parameters::{Network, NetworkUpgrade::*},
+    serialization::ZcashSerialize,
+    transaction::Transaction,
+    transparent::{Address, Output, Script},
 };
 
-use crate::{
-    block::subsidy::general::block_subsidy,
-    parameters::subsidy::{
-        FundingStreamReceiver, FUNDING_STREAM_HEIGHT_RANGES, FUNDING_STREAM_RECEIVER_DENOMINATOR,
-        FUNDING_STREAM_RECEIVER_NUMERATORS,
-    },
-};
+use crate::{block::subsidy::general::block_subsidy, parameters::subsidy::*};
+
+use std::{collections::HashMap, str::FromStr};
 
 #[cfg(test)]
 mod tests;
 
 /// Returns the `fs.Value(height)` for each stream receiver
-/// as described in [protocol specification §7.7][7.7]
+/// as described in [protocol specification §7.8][7.8]
 ///
-/// [7.7]: https://zips.z.cash/protocol/protocol.pdf#subsidies
-use std::collections::HashMap;
+/// [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 pub fn funding_stream_values(
     height: Height,
     network: Network,
@@ -44,4 +42,115 @@ pub fn funding_stream_values(
         }
     }
     Ok(results)
+}
+
+/// Returns the minumum height after the first halving
+/// as described in [protocol specification §7.10][7.10]
+///
+/// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+fn height_for_halving(network: Network) -> Height {
+    // First halving on Mainnet is at Canopy
+    // while in Testnet is at block 1_116_000
+    // https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams
+    match network {
+        Network::Mainnet => Canopy
+            .activation_height(network)
+            .expect("canopy activation height should be available"),
+        Network::Testnet => Height(1_116_000),
+    }
+}
+
+/// Returns the address change period
+/// as described in [protocol specification §7.10][7.10]
+///
+/// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+fn funding_stream_address_period(height: Height, network: Network) -> u32 {
+    (height.0 + (POST_BLOSSOM_HALVING_INTERVAL.0) - (height_for_halving(network).0))
+        / (FUNDING_STREAM_ADDRESS_CHANGE_INTERVAL.0)
+}
+
+/// Returns the position in the address slice for each funding stream
+/// as described in [protocol specification §7.10][7.10]
+///
+/// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams
+fn funding_stream_address_index(height: Height, network: Network) -> usize {
+    let num_addresses = match network {
+        Network::Mainnet => FUNDING_STREAMS_N_ADDRESSES_MAINNET,
+        Network::Testnet => FUNDING_STREAMS_N_ADDRESSES_TESTNET,
+    };
+
+    let index = 1u32
+        .checked_add(funding_stream_address_period(height, network))
+        .unwrap()
+        .checked_sub(funding_stream_address_period(
+            FUNDING_STREAM_HEIGHT_RANGES.get(&network).unwrap().start,
+            network,
+        ))
+        .unwrap() as usize;
+    assert!(index > 0 && index <= num_addresses);
+
+    index
+}
+
+/// Return the address corresponding to this height for this funding stream receiver.
+pub fn funding_stream_address(
+    height: Height,
+    network: Network,
+    receiver: FundingStreamReceiver,
+) -> Address {
+    let index = funding_stream_address_index(height, network) - 1;
+
+    let address = match receiver {
+        FundingStreamReceiver::Ecc => match network {
+            Network::Mainnet => FUNDING_STREAM_ECC_ADDRESSES_MAINNET[index].to_string(),
+            Network::Testnet => FUNDING_STREAM_ECC_ADDRESSES_TESTNET[index].to_string(),
+        },
+        FundingStreamReceiver::ZcashFoundation => match network {
+            Network::Mainnet => FUNDING_STREAM_ZF_ADDRESSES_MAINNET[index].to_string(),
+            Network::Testnet => FUNDING_STREAM_ZF_ADDRESSES_TESTNET[index].to_string(),
+        },
+        FundingStreamReceiver::MajorGrants => match network {
+            Network::Mainnet => FUNDING_STREAM_MG_ADDRESSES_MAINNET[index].to_string(),
+            Network::Testnet => FUNDING_STREAM_MG_ADDRESSES_TESTNET[index].to_string(),
+        },
+    };
+    Address::from_str(&address).expect("Address should deserialize")
+}
+
+/// Given a founders reward address, create a script and check if it is the same
+/// as the given lock_script as described in [protocol specification §7.10][7.10]
+///
+/// [7.10]: https://zips.z.cash/protocol/protocol.pdf#fundingstreams.
+pub fn check_script_form(lock_script: Script, address: Address) -> bool {
+    let mut address_hash = address
+        .zcash_serialize_to_vec()
+        .expect("we should get address bytes here");
+
+    address_hash = address_hash[2..22].to_vec();
+    address_hash.insert(0, OpCode::Push20Bytes as u8);
+    address_hash.insert(0, OpCode::Hash160 as u8);
+    address_hash.insert(address_hash.len(), OpCode::Equal as u8);
+    if lock_script.as_raw_bytes().len() == address_hash.len()
+        && lock_script == Script::new(&address_hash)
+    {
+        return true;
+    }
+    false
+}
+
+/// Returns a list of outputs in `Transaction`, which have a script address equal to `Address`.
+pub fn find_output_with_address(transaction: &Transaction, address: Address) -> Vec<Output> {
+    transaction
+        .outputs()
+        .iter()
+        .filter(|o| check_script_form(o.lock_script.clone(), address))
+        .cloned()
+        .collect()
+}
+
+/// Script opcodes needed to compare the `lock_script` with the funding stream reward address.
+pub enum OpCode {
+    Equal = 0x87,
+    Hash160 = 0xa9,
+    Push20Bytes = 0x14,
 }

--- a/zebra-consensus/src/block/subsidy/general.rs
+++ b/zebra-consensus/src/block/subsidy/general.rs
@@ -16,9 +16,9 @@ use crate::parameters::subsidy::*;
 
 /// The divisor used for halvings.
 ///
-/// `1 << Halving(height)`, as described in [protocol specification §7.7][7.7]
+/// `1 << Halving(height)`, as described in [protocol specification §7.8][7.8]
 ///
-/// [7.7]: https://zips.z.cash/protocol/protocol.pdf#subsidies
+/// [7.8]: https://zips.z.cash/protocol/protocol.pdf#subsidies
 pub fn halving_divisor(height: Height, network: Network) -> u64 {
     let blossom_height = Blossom
         .activation_height(network)

--- a/zebra-consensus/src/block/tests.rs
+++ b/zebra-consensus/src/block/tests.rs
@@ -489,7 +489,7 @@ fn funding_stream_validation_failure() -> Result<(), Report> {
     // Validate it
     let result = check::subsidy_is_valid(&block, network).unwrap_err();
     let expected = BlockError::Transaction(TransactionError::Subsidy(
-        SubsidyError::FundingStreamNotFound,
+        SubsidyError::FundingStreamValueNotFound,
     ));
     assert_eq!(expected, result);
 

--- a/zebra-consensus/src/error.rs
+++ b/zebra-consensus/src/error.rs
@@ -22,8 +22,11 @@ pub enum SubsidyError {
     #[error("founders reward output not found")]
     FoundersRewardNotFound,
 
-    #[error("funding stream output not found")]
-    FundingStreamNotFound,
+    #[error("funding stream output with value not found")]
+    FundingStreamValueNotFound,
+
+    #[error("funding stream output with address not found")]
+    FundingStreamAddressNotFound,
 }
 
 #[derive(Error, Clone, Debug, PartialEq, Eq)]

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -82,3 +82,139 @@ lazy_static! {
         hash_map
     };
 }
+
+/// Address change interval function here as a constant
+/// as described in [protocol specification §7.9.1][7.9.1].
+///
+/// [7.9.1]: https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams
+pub const FUNDING_STREAM_ADDRESS_CHANGE_INTERVAL: Height =
+    Height(POST_BLOSSOM_HALVING_INTERVAL.0 / 48);
+
+/// Number of addresses for each funding stream in the Mainnet
+pub const FUNDING_STREAMS_N_ADDRESSES_MAINNET: usize = 48;
+
+/// List of addresses for the ECC funding stream in the Mainnet.
+pub const FUNDING_STREAM_ECC_ADDRESSES_MAINNET: [&str; FUNDING_STREAMS_N_ADDRESSES_MAINNET] = [
+    "t3LmX1cxWPPPqL4TZHx42HU3U5ghbFjRiif",
+    "t3Toxk1vJQ6UjWQ42tUJz2rV2feUWkpbTDs",
+    "t3ZBdBe4iokmsjdhMuwkxEdqMCFN16YxKe6",
+    "t3ZuaJziLM8xZ32rjDUzVjVtyYdDSz8GLWB",
+    "t3bAtYWa4bi8VrtvqySxnbr5uqcG9czQGTZ",
+    "t3dktADfb5Rmxncpe1HS5BRS5Gcj7MZWYBi",
+    "t3hgskquvKKoCtvxw86yN7q8bzwRxNgUZmc",
+    "t3R1VrLzwcxAZzkX4mX3KGbWpNsgtYtMntj",
+    "t3ff6fhemqPMVujD3AQurxRxTdvS1pPSaa2",
+    "t3cEUQFG3KYnFG6qYhPxSNgGi3HDjUPwC3J",
+    "t3WR9F5U4QvUFqqx9zFmwT6xFqduqRRXnaa",
+    "t3PYc1LWngrdUrJJbHkYPCKvJuvJjcm85Ch",
+    "t3bgkjiUeatWNkhxY3cWyLbTxKksAfk561R",
+    "t3Z5rrR8zahxUpZ8itmCKhMSfxiKjUp5Dk5",
+    "t3PU1j7YW3fJ67jUbkGhSRto8qK2qXCUiW3",
+    "t3S3yaT7EwNLaFZCamfsxxKwamQW2aRGEkh",
+    "t3eutXKJ9tEaPSxZpmowhzKhPfJvmtwTEZK",
+    "t3gbTb7brxLdVVghSPSd3ycGxzHbUpukeDm",
+    "t3UCKW2LrHFqPMQFEbZn6FpjqnhAAbfpMYR",
+    "t3NyHsrnYbqaySoQqEQRyTWkjvM2PLkU7Uu",
+    "t3QEFL6acxuZwiXtW3YvV6njDVGjJ1qeaRo",
+    "t3PdBRr2S1XTDzrV8bnZkXF3SJcrzHWe1wj",
+    "t3ZWyRPpWRo23pKxTLtWsnfEKeq9T4XPxKM",
+    "t3he6QytKCTydhpztykFsSsb9PmBT5JBZLi",
+    "t3VWxWDsLb2TURNEP6tA1ZSeQzUmPKFNxRY",
+    "t3NmWLvZkbciNAipauzsFRMxoZGqmtJksbz",
+    "t3cKr4YxVPvPBG1mCvzaoTTdBNokohsRJ8n",
+    "t3T3smGZn6BoSFXWWXa1RaoQdcyaFjMfuYK",
+    "t3gkDUe9Gm4GGpjMk86TiJZqhztBVMiUSSA",
+    "t3eretuBeBXFHe5jAqeSpUS1cpxVh51fAeb",
+    "t3dN8g9zi2UGJdixGe9txeSxeofLS9t3yFQ",
+    "t3S799pq9sYBFwccRecoTJ3SvQXRHPrHqvx",
+    "t3fhYnv1S5dXwau7GED3c1XErzt4n4vDxmf",
+    "t3cmE3vsBc5xfDJKXXZdpydCPSdZqt6AcNi",
+    "t3h5fPdjJVHaH4HwynYDM5BB3J7uQaoUwKi",
+    "t3Ma35c68BgRX8sdLDJ6WR1PCrKiWHG4Da9",
+    "t3LokMKPL1J8rkJZvVpfuH7dLu6oUWqZKQK",
+    "t3WFFGbEbhJWnASZxVLw2iTJBZfJGGX73mM",
+    "t3L8GLEsUn4QHNaRYcX3EGyXmQ8kjpT1zTa",
+    "t3PgfByBhaBSkH8uq4nYJ9ZBX4NhGCJBVYm",
+    "t3WecsqKDhWXD4JAgBVcnaCC2itzyNZhJrv",
+    "t3ZG9cSfopnsMQupKW5v9sTotjcP5P6RTbn",
+    "t3hC1Ywb5zDwUYYV8LwhvF5rZ6m49jxXSG5",
+    "t3VgMqDL15ZcyQDeqBsBW3W6rzfftrWP2yB",
+    "t3LC94Y6BwLoDtBoK2NuewaEbnko1zvR9rm",
+    "t3cWCUZJR3GtALaTcatrrpNJ3MGbMFVLRwQ",
+    "t3YYF4rPLVxDcF9hHFsXyc5Yq1TFfbojCY6",
+    "t3XHAGxRP2FNfhAjxGjxbrQPYtQQjc3RCQD",
+];
+
+/// List of addresses for the Zcash Foundation funding stream in the Mainnet.
+pub const FUNDING_STREAM_ZF_ADDRESSES_MAINNET: [&str; 48] =
+    ["t3dvVE3SQEi7kqNzwrfNePxZ1d4hUyztBA1"; FUNDING_STREAMS_N_ADDRESSES_MAINNET];
+
+/// List of addresses for the Major Grants funding stream in the Mainnet.
+pub const FUNDING_STREAM_MG_ADDRESSES_MAINNET: [&str; 48] =
+    ["t3XyYW8yBFRuMnfvm5KLGFbEVz25kckZXym"; FUNDING_STREAMS_N_ADDRESSES_MAINNET];
+
+/// Number of addresses for each funding stream in the Mainnet
+pub const FUNDING_STREAMS_N_ADDRESSES_TESTNET: usize = 51;
+
+/// List of addresses for the ECC funding stream in the Testnet.
+pub const FUNDING_STREAM_ECC_ADDRESSES_TESTNET: [&str; FUNDING_STREAMS_N_ADDRESSES_TESTNET] = [
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t2NNHrgPpE388atmWSF4DxAb3xAoW5Yp45M",
+    "t2VMN28itPyMeMHBEd9Z1hm6YLkQcGA1Wwe",
+    "t2CHa1TtdfUV8UYhNm7oxbzRyfr8616BYh2",
+    "t2F77xtr28U96Z2bC53ZEdTnQSUAyDuoa67",
+    "t2ARrzhbgcpoVBDPivUuj6PzXzDkTBPqfcT",
+    "t278aQ8XbvFR15mecRguiJDQQVRNnkU8kJw",
+    "t2Dp1BGnZsrTXZoEWLyjHmg3EPvmwBnPDGB",
+    "t2KzeqXgf4ju33hiSqCuKDb8iHjPCjMq9iL",
+    "t2Nyxqv1BiWY1eUSiuxVw36oveawYuo18tr",
+    "t2DKFk5JRsVoiuinK8Ti6eM4Yp7v8BbfTyH",
+    "t2CUaBca4k1x36SC4q8Nc8eBoqkMpF3CaLg",
+    "t296SiKL7L5wvFmEdMxVLz1oYgd6fTfcbZj",
+    "t29fBCFbhgsjL3XYEZ1yk1TUh7eTusB6dPg",
+    "t2FGofLJXa419A76Gpf5ncxQB4gQXiQMXjK",
+    "t2ExfrnRVnRiXDvxerQ8nZbcUQvNvAJA6Qu",
+    "t28JUffLp47eKPRHKvwSPzX27i9ow8LSXHx",
+    "t2JXWPtrtyL861rFWMZVtm3yfgxAf4H7uPA",
+    "t2QdgbJoWfYHgyvEDEZBjHmgkr9yNJff3Hi",
+    "t2QW43nkco8r32ZGRN6iw6eSzyDjkMwCV3n",
+    "t2DgYDXMJTYLwNcxighQ9RCgPxMVATRcUdC",
+    "t2Bop7dg33HGZx3wunnQzi2R2ntfpjuti3M",
+    "t2HVeEwovcLq9RstAbYkqngXNEsCe2vjJh9",
+    "t2HxbP5keQSx7p592zWQ5bJ5GrMmGDsV2Xa",
+    "t2TJzUg2matao3mztBRJoWnJY6ekUau6tPD",
+    "t29pMzxmo6wod25YhswcjKv3AFRNiBZHuhj",
+    "t2QBQMRiJKYjshJpE6RhbF7GLo51yE6d4wZ",
+    "t2F5RqnqguzZeiLtYHFx4yYfy6pDnut7tw5",
+    "t2CHvyZANE7XCtg8AhZnrcHCC7Ys1jJhK13",
+    "t2BRzpMdrGWZJ2upsaNQv6fSbkbTy7EitLo",
+    "t2BFixHGQMAWDY67LyTN514xRAB94iEjXp3",
+    "t2Uvz1iVPzBEWfQBH1p7NZJsFhD74tKaG8V",
+    "t2CmFDj5q6rJSRZeHf1SdrowinyMNcj438n",
+    "t2ErNvWEReTfPDBaNizjMPVssz66aVZh1hZ",
+    "t2GeJQ8wBUiHKDVzVM5ZtKfY5reCg7CnASs",
+    "t2L2eFtkKv1G6j55kLytKXTGuir4raAy3yr",
+    "t2EK2b87dpPazb7VvmEGc8iR6SJ289RywGL",
+    "t2DJ7RKeZJxdA4nZn8hRGXE8NUyTzjujph9",
+    "t2K1pXo4eByuWpKLkssyMLe8QKUbxnfFC3H",
+    "t2TB4mbSpuAcCWkH94Leb27FnRxo16AEHDg",
+    "t2Phx4gVL4YRnNsH3jM1M7jE4Fo329E66Na",
+    "t2VQZGmeNomN8c3USefeLL9nmU6M8x8CVzC",
+    "t2RicCvTVTY5y9JkreSRv3Xs8q2K67YxHLi",
+    "t2JrSLxTGc8wtPDe9hwbaeUjCrCfc4iZnDD",
+    "t2Uh9Au1PDDSw117sAbGivKREkmMxVC5tZo",
+    "t2FDwoJKLeEBMTy3oP7RLQ1Fihhvz49a3Bv",
+    "t2FY18mrgtb7QLeHA8ShnxLXuW8cNQ2n1v8",
+    "t2L15TkDYum7dnQRBqfvWdRe8Yw3jVy9z7g",
+];
+
+/// List of addresses for the Zcash Foundation funding stream in the Testnet.
+pub const FUNDING_STREAM_ZF_ADDRESSES_TESTNET: [&str; FUNDING_STREAMS_N_ADDRESSES_TESTNET] =
+    ["t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v"; FUNDING_STREAMS_N_ADDRESSES_TESTNET];
+
+/// List of addresses for the Major Grants funding stream in the Testnet.
+pub const FUNDING_STREAM_MG_ADDRESSES_TESTNET: [&str; FUNDING_STREAMS_N_ADDRESSES_TESTNET] =
+    ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"; FUNDING_STREAMS_N_ADDRESSES_TESTNET];

--- a/zebra-consensus/src/parameters/subsidy.rs
+++ b/zebra-consensus/src/parameters/subsidy.rs
@@ -53,6 +53,18 @@ pub enum FundingStreamReceiver {
     MajorGrants,
 }
 
+impl FundingStreamReceiver {
+    /// Get a list of receiver types
+    pub fn receivers() -> Vec<Self> {
+        vec![Self::Ecc, Self::ZcashFoundation, Self::MajorGrants]
+    }
+}
+
+/// The number of funding stream entities.
+pub const FUNDING_STREAM_RECEIVERS_NUMBER: usize = 3;
+
+/// The funding stream receiver categories
+
 /// Denominator as described in [protocol specification §7.9.1][7.9.1].
 ///
 /// [7.9.1]: https://zips.z.cash/protocol/protocol.pdf#zip214fundingstreams


### PR DESCRIPTION
## Motivation

We need to validate the coinbase output addresses against the funding stream receivers. Part of https://github.com/ZcashFoundation/zebra/issues/338

### Specifications

[TBA]

### Designs

[TBA]

## Solution

This is based on https://github.com/ZcashFoundation/zebra/pull/3017 and it still needs a bunch of work. It is published so we can have the big picture of all we need to get done.

It needs adjustments in almost all calls and further test coverage. Right now it is passing test blocks and a quick test will be to sync up to tip however i didnt made this yet as the code is constantly changed.

## Review

Will be useful for @teor4321 as they are reviewing https://github.com/ZcashFoundation/zebra/pull/3017

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work