### PR TITLE
fix(rpc): ignore non-standard "jsonrpc = 1.0" in lightwalletd requests

### DIFF
--- a/zebra-rpc/src/rpc.rs
+++ b/zebra-rpc/src/rpc.rs
@@ -11,6 +11,10 @@ pub trait Rpc {
     /// getinfo
     #[rpc(name = "getinfo")]
     fn getinfo(&self) -> Result<GetInfo>;
+
+    /// getblockchaininfo
+    #[rpc(name = "getblockchaininfo")]
+    fn getblockchaininfo(&self) -> Result<GetBlockChainInfo>;
 }
 
 /// RPC method implementations.
@@ -25,6 +29,15 @@ impl Rpc for RpcImpl {
 
         Ok(info)
     }
+
+    fn getblockchaininfo(&self) -> Result<GetBlockChainInfo> {
+        // TODO: dummy output data, fix in the context of #3143
+        let response = GetBlockChainInfo {
+            chain: "main".to_string(),
+        };
+
+        Ok(response)
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -32,4 +45,11 @@ impl Rpc for RpcImpl {
 pub struct GetInfo {
     build: String,
     subversion: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+/// Response to a `getblockchaininfo` RPC request.
+pub struct GetBlockChainInfo {
+    chain: String,
+    // TODO: add other fields used by lightwalletd (#3143)
 }

--- a/zebrad/src/components/rpc.rs
+++ b/zebrad/src/components/rpc.rs
@@ -3,7 +3,7 @@
 use futures::TryStreamExt;
 use hyper::{body::Bytes, Body};
 use jsonrpc_core;
-use jsonrpc_http_server::{DomainsValidation, RequestMiddleware, ServerBuilder};
+use jsonrpc_http_server::{RequestMiddleware, ServerBuilder};
 
 use zebra_rpc::rpc::{Rpc, RpcImpl};
 
@@ -28,8 +28,8 @@ impl RpcServer {
                 // TODO: use the same tokio executor as the rest of Zebra
                 //.event_loop_executor(tokio::runtime::Handle::current())
                 .threads(1)
-                // TODO: if we enable this security check, does lightwalletd still work?
-                .allowed_hosts(DomainsValidation::Disabled)
+                // TODO: disable this security check if we see errors from lightwalletd.
+                //.allowed_hosts(DomainsValidation::Disabled)
                 .request_middleware(FixHttpRequestMiddleware)
                 .start_http(&config.listen_addr)
                 .expect("Unable to start RPC server");
@@ -88,8 +88,8 @@ impl RequestMiddleware for FixHttpRequestMiddleware {
         });
 
         jsonrpc_http_server::RequestMiddlewareAction::Proceed {
-            // TODO: if we enable this security check, does lightwalletd still work?
-            should_continue_on_invalid_cors: true,
+            // TODO: disable this security check if we see errors from lightwalletd.
+            should_continue_on_invalid_cors: false,
             request,
         }
     }

--- a/zebrad/src/components/rpc.rs
+++ b/zebrad/src/components/rpc.rs
@@ -1,8 +1,9 @@
 //! An RPC endpoint.
 
+use futures::TryStreamExt;
+use hyper::{body::Bytes, Body};
 use jsonrpc_core;
-
-use jsonrpc_http_server::ServerBuilder;
+use jsonrpc_http_server::{DomainsValidation, RequestMiddleware, ServerBuilder};
 
 use zebra_rpc::rpc::{Rpc, RpcImpl};
 
@@ -24,7 +25,12 @@ impl RpcServer {
             io.extend_with(RpcImpl.to_delegate());
 
             let server = ServerBuilder::new(io)
+                // TODO: use the same tokio executor as the rest of Zebra
+                //.event_loop_executor(tokio::runtime::Handle::current())
                 .threads(1)
+                // TODO: if we enable this security check, does lightwalletd still work?
+                .allowed_hosts(DomainsValidation::Disabled)
+                .request_middleware(FixHttpRequestMiddleware)
                 .start_http(&config.listen_addr)
                 .expect("Unable to start RPC server");
 
@@ -33,5 +39,74 @@ impl RpcServer {
             server.wait();
         }
         RpcServer {}
+    }
+}
+
+/// HTTP [`RequestMiddleware`] with compatibility wrokarounds.
+///
+/// This middleware makes the following changes to requests:
+///
+/// ## JSON RPC 1.0 `jsonrpc` field
+///
+/// Removes "jsonrpc: 1.0" fields from requests,
+/// because the "jsonrpc" field was only added in JSON-RPC 2.0.
+///
+/// <http://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0>
+//
+// TODO: put this HTTP middleware in a separate module
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct FixHttpRequestMiddleware;
+
+impl RequestMiddleware for FixHttpRequestMiddleware {
+    fn on_request(
+        &self,
+        request: hyper::Request<hyper::Body>,
+    ) -> jsonrpc_http_server::RequestMiddlewareAction {
+        let request = request.map(|body| {
+            let body = body.map_ok(|data| {
+                // To simplify data handling, we assume that any search strings won't be split
+                // across multiple `Bytes` data buffers.
+                //
+                // To simplify error handling, Zebra only supports valid UTF-8 requests,
+                // and uses lossy UTF-8 conversion.
+                //
+                // JSON-RPC requires all requests to be valid UTF-8.
+                // The lower layers should reject invalid requests with lossy changes.
+                // But if they accept some lossy changes, that's ok,
+                // because the request was non-standard anyway.
+                //
+                // We're not concerned about performance here, so we just clone the Cow<str>
+                let data = String::from_utf8_lossy(data.as_ref()).to_string();
+
+                // Fix up the request.
+                let data = Self::remove_json_1_fields(data);
+
+                Bytes::from(data)
+            });
+
+            Body::wrap_stream(body)
+        });
+
+        jsonrpc_http_server::RequestMiddlewareAction::Proceed {
+            // TODO: if we enable this security check, does lightwalletd still work?
+            should_continue_on_invalid_cors: true,
+            request,
+        }
+    }
+}
+
+impl FixHttpRequestMiddleware {
+    /// Remove any "jsonrpc: 1.0" fields in `data`, and return the resulting string.
+    pub fn remove_json_1_fields(data: String) -> String {
+        // Replace "jsonrpc = 1.0":
+        // - at the start or middle of a list, and
+        // - at the end of a list;
+        // with no spaces (lightwalletd format), and spaces after separators (example format).
+        //
+        // TODO: replace this with a regular expression if we see errors from lightwalletd.
+        data.replace("\"jsonrpc\":\"1.0\",", "")
+            .replace("\"jsonrpc\": \"1.0\",", "")
+            .replace(",\"jsonrpc\":\"1.0\"", "")
+            .replace(", \"jsonrpc\": \"1.0\"", "")
     }
 }


### PR DESCRIPTION
## Motivation

`lightwalletd` sends a "jsonrpc: 1.0" field in its RPC requests. But this field was only added in JSON-RPC 2.0, so `jsonrpc_core` rejects it.

### Specifications

jsonrpc field:
http://www.simple-is-better.org/rpc/#differences-between-1-0-and-2-0

Valid jsonrpc_core versions:
https://docs.rs/jsonrpc-core/18.0.0/jsonrpc_core/types/request/struct.MethodCall.html#structfield.jsonrpc
https://docs.rs/jsonrpc-core/18.0.0/jsonrpc_core/types/version/enum.Version.html

## Solution

- delete the non-standard fields before parsing the request

Based on https://github.com/ZcashFoundation/zebra/pull/3589

## Review

I'd like both @oxarbitrage and @jvff to have a look at this fix.

This fix doesn't have tests yet, but I've tested it manually.

### Reviewer Checklist

  - [ ] Code implements Specs and Designs
  - [ ] Tests for Expected Behaviour
  - [ ] Tests for Errors

## Follow Up Work

- add tests with a `lightwalletd` instance